### PR TITLE
Improve NPC sheet UI and clarify movement/init logic

### DIFF
--- a/css/sla-industries.css
+++ b/css/sla-industries.css
@@ -700,6 +700,17 @@
     padding: 2px;
     border-bottom: 1px dashed #ccc;
     align-items: center;
+    display: flex; /* Ensure flex behavior */
+}
+
+/* FIX: Force Image Size */
+.threat-item img {
+    flex: 0 0 24px; /* Don't grow, don't shrink, fixed 24px */
+    width: 24px;
+    height: 24px;
+    object-fit: cover;
+    margin-right: 5px;
+    border: 1px solid #000;
 }
 
 .threat-item .item-name {
@@ -710,6 +721,18 @@
 .threat-item .item-name:hover {
     color: #a00;
     text-shadow: none;
+}
+
+/* Ensure controls are visible */
+.threat-item .item-controls {
+    display: flex;
+    gap: 5px;
+}
+.threat-item .item-controls a {
+    color: #555;
+}
+.threat-item .item-controls a:hover {
+    color: #d00;
 }
 
 /* 6. Editor Fix for White Paper */

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -46,7 +46,8 @@
             <div class="threat-box">
                 <label>INIT</label>
                 <div class="flexrow">
-                    <span style="font-weight:bold; font-size:1.2em;">{{system.stats.init.value}}</span>
+                    {{!-- FIX: Changed from Span to Input --}}
+                    <input type="number" name="system.stats.init.value" value="{{system.stats.init.value}}" style="font-weight:bold; font-size:1.2em; border:none; background:transparent; text-align:center; width: 50px;"/>
                     <a class="rollable" data-roll-type="init"><i class="fas fa-dice-d10"></i></a>
                 </div>
             </div>
@@ -64,8 +65,8 @@
         <div class="threat-section-bar">SKILLS & WEAPONS</div>
         <div class="threat-content-box">
             {{#each gear as |item|}}
-            <div class="threat-item flexrow">
-                <img src="{{item.img}}" width="24" height="24"/>
+            <div class="item threat-item flexrow" data-item-id="{{item._id}}">
+                <img src="{{item.img}}"/>
                 <span class="item-name rollable" data-roll-type="item" style="font-weight:bold;">{{item.name}}</span>
                 <div class="item-controls">
                     <a class="item-edit" title="Edit"><i class="fas fa-edit"></i></a>
@@ -74,9 +75,9 @@
             </div>
             {{/each}}
             {{#each skills as |skill|}}
-            <div class="threat-item flexrow">
-                <span class="item-name rollable" data-roll-type="skill">{{skill.name}}</span>
-                <span style="color:#666;"> ({{skill.system.rank}})</span>
+            <div class="item threat-item flexrow" data-item-id="{{skill._id}}">
+                <span class="item-name rollable" data-roll-type="skill" style="padding-left:5px;">{{skill.name}}</span>
+                <span style="color:#666; margin-right:5px;"> ({{skill.system.rank}})</span>
                 <div class="item-controls">
                     <a class="item-edit"><i class="fas fa-edit"></i></a>
                     <a class="item-delete"><i class="fas fa-trash"></i></a>


### PR DESCRIPTION
Refines the NPC sheet by making initiative editable, standardizing item/skill display, and improving item control visibility. CSS updates ensure consistent image sizing and control styling. In actor.mjs, clarifies that NPC initiative and movement values are manual and not auto-calculated, while characters retain auto-calculation. Removes redundant comments and streamlines logic for better maintainability.