### PR TITLE
Add Office Dossier theme for species and package items

### DIFF
--- a/css/sla-industries.css
+++ b/css/sla-industries.css
@@ -909,3 +909,115 @@
     flex: 1;
     overflow: hidden; /* Prevent text spill */
 }
+
+/* --- D. OFFICE DOSSIER THEME (Species, Package) --- */
+.item.species-theme, .item.package-theme {
+    background: #f4e4bc; /* Manila Folder Beige */
+    color: #333;
+    font-family: "Courier Prime", "Courier New", monospace;
+    border: 1px solid #c7b28a;
+}
+
+.item.species-theme .sheet-header, .item.package-theme .sheet-header {
+    background: rgba(0,0,0,0.05);
+    border-bottom: 2px solid #555;
+}
+
+.item.species-theme input, .item.package-theme input {
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid #555;
+    color: #000;
+    font-family: "Courier New", monospace;
+    font-weight: bold;
+}
+
+.office-dossier {
+    padding: 10px;
+}
+
+.dossier-stamp {
+    border: 2px solid #d00;
+    color: #d00;
+    display: inline-block;
+    padding: 2px 10px;
+    font-weight: bold;
+    transform: rotate(-2deg);
+    margin-bottom: 15px;
+    font-family: "Arial Black", sans-serif;
+    opacity: 0.7;
+}
+
+.paper-section {
+    margin-bottom: 15px;
+    border: 1px solid #ccc;
+    padding: 5px;
+    background: rgba(255,255,255,0.3);
+}
+
+.paper-header {
+    background: #333;
+    color: #fff;
+    padding: 2px 5px;
+    font-size: 0.8em;
+    text-transform: uppercase;
+    margin-bottom: 5px;
+}
+
+.paper-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+/* Stat Grid for Species/Package */
+.stat-limits-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 5px;
+}
+
+.limit-box {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px dotted #999;
+    padding: 2px;
+}
+.limit-box label { font-size: 0.8em; font-weight: bold; }
+.limit-box input { width: 30px; text-align: center; }
+
+/* Skill Granting Area */
+.skill-grant-area {
+    min-height: 60px;
+    border: 2px dashed #999;
+    padding: 5px;
+    background: rgba(0,0,0,0.02);
+}
+
+.granted-skill-chip {
+    display: inline-flex;
+    align-items: center;
+    background: #e0e0e0;
+    border: 1px solid #999;
+    padding: 2px 6px;
+    margin: 2px;
+    border-radius: 3px;
+    font-size: 0.9em;
+}
+
+.delete-grant {
+    margin-left: 5px;
+    color: #d00;
+    cursor: pointer;
+}
+.delete-grant:hover { color: #f00; }
+
+.empty-dossier-text {
+    width: 100%;
+    text-align: center;
+    color: #777;
+    font-style: italic;
+    padding-top: 15px;
+}

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "0.2.5-alpha",
+  "version": "0.2.6-alpha",
   "compatibility": {
     "minimum": "13",
     "verified": "13.351"
@@ -29,5 +29,5 @@
   "secondaryTokenAttribute": "attributes.flux",
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.2.5/sla-foundry.zip"
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.2.6/sla-foundry.zip"
 }

--- a/templates/item/item-sheet.hbs
+++ b/templates/item/item-sheet.hbs
@@ -1,11 +1,10 @@
 <form class="{{cssClass}} sla-sheet sheet item {{item.type}}-theme" autocomplete="off">
     
-    {{!-- HEADER (Theme specific styles will handle the look) --}}
+    {{!-- HEADER --}}
     <header class="sheet-header">
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
         <div class="header-details">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Item Name"/></h1>
-            
             <div class="item-subtitle">
                 <span class="type-label">{{item.type}}</span>
                 {{#if (or (eq item.type "skill") (eq item.type "discipline"))}}
@@ -15,106 +14,116 @@
         </div>
     </header>
 
-    {{!-- NAVIGATION --}}
+    {{!-- TABS --}}
     <nav class="sheet-tabs tabs" data-group="primary">
         <a class="item" data-tab="attributes">Details</a>
         <a class="item" data-tab="description">Description</a>
     </nav>
 
-    {{!-- SHEET BODY --}}
+    {{!-- BODY --}}
     <section class="sheet-body">
 
         {{!-- ATTRIBUTES TAB --}}
         <div class="tab attributes" data-group="primary" data-tab="attributes">
             
-            {{!-- WEAPON / GEAR SPECIFIC --}}
+            {{!-- 1. CATALOGUE THEME (Gear) --}}
             {{#if (or (eq item.type "weapon") (eq item.type "item") (eq item.type "armor") (eq item.type "drug"))}}
             <div class="catalogue-grid">
-                <div class="form-group">
-                    <label>Weight</label>
-                    <input type="number" name="system.weight" value="{{system.weight}}" step="0.1"/>
-                </div>
-                <div class="form-group">
-                    <label>Cost</label>
-                    <input type="number" name="system.price" value="{{system.price}}"/>
-                </div>
+                <div class="form-group"><label>Weight</label><input type="number" name="system.weight" value="{{system.weight}}" step="0.1"/></div>
+                <div class="form-group"><label>Cost</label><input type="number" name="system.price" value="{{system.price}}"/></div>
                 {{#if (eq item.type "weapon")}}
-                <div class="form-group">
-                    <label>Damage</label>
-                    <input type="text" name="system.damage" value="{{system.damage}}"/>
-                </div>
-                <div class="form-group">
-                    <label>Recoil</label>
-                    <input type="text" name="system.recoil" value="{{system.recoil}}"/>
-                </div>
-                <div class="form-group">
-                    <label>Skill</label>
-                    <select name="system.skill">
-                        {{selectOptions config.combatSkills selected=system.skill}}
-                    </select>
-                </div>
+                <div class="form-group"><label>Damage</label><input type="text" name="system.damage" value="{{system.damage}}"/></div>
+                <div class="form-group"><label>Recoil</label><input type="text" name="system.recoil" value="{{system.recoil}}"/></div>
+                <div class="form-group"><label>Skill</label><select name="system.skill">{{selectOptions config.combatSkills selected=system.skill}}</select></div>
                 {{/if}}
                 {{#if (eq item.type "armor")}}
-                <div class="form-group">
-                    <label>PV</label>
-                    <input type="number" name="system.pv" value="{{system.pv}}"/>
+                <div class="form-group"><label>PV</label><input type="number" name="system.pv" value="{{system.pv}}"/></div>
+                <div class="form-group"><label>Resist (Cur/Max)</label>
+                    <div class="flexrow"><input type="number" name="system.resistance.value" value="{{system.resistance.value}}"/> / <input type="number" name="system.resistance.max" value="{{system.resistance.max}}"/></div>
                 </div>
-                <div class="form-group">
-                    <label>Resist</label>
-                    <div class="flexrow">
-                        <input type="number" name="system.resistance.value" value="{{system.resistance.value}}" placeholder="Cur"/>
-                        /
-                        <input type="number" name="system.resistance.max" value="{{system.resistance.max}}" placeholder="Max"/>
+                {{/if}}
+            </div>
+            {{/if}}
+
+            {{!-- 2. ACADEMIC THEME (Skills) --}}
+            {{#if (or (eq item.type "skill") (eq item.type "trait"))}}
+            <div class="academic-paper">
+                <div class="form-group line-item"><label>Related Stat:</label><select name="system.stat">{{selectOptions config.stats selected=system.stat}}</select></div>
+                <div class="form-group line-item"><label>XP Cost:</label><input type="number" name="system.xpCost" value="{{system.xpCost}}"/></div>
+            </div>
+            {{/if}}
+
+            {{!-- 3. SPECTRAL THEME (Ebb) --}}
+            {{#if (or (eq item.type "ebbFormula") (eq item.type "discipline"))}}
+            <div class="spectral-container">
+                <div class="form-group glow-input"><label>Flux Cost</label><input type="number" name="system.cost" value="{{system.cost}}"/></div>
+                {{#if (eq item.type "ebbFormula")}}
+                <div class="form-group glow-input"><label>Formula Rating</label><input type="number" name="system.formulaRating" value="{{system.formulaRating}}"/></div>
+                <div class="form-group glow-input"><label>Discipline</label><select name="system.discipline">{{selectOptions config.disciplineSkills selected=system.discipline}}</select></div>
+                {{/if}}
+            </div>
+            {{/if}}
+
+            {{!-- 4. OFFICE DOSSIER THEME (Species & Packages) --}}
+            {{#if (or (eq item.type "species") (eq item.type "package"))}}
+            <div class="office-dossier">
+                <div class="dossier-stamp">CONFIDENTIAL RECORD</div>
+                
+                {{!-- SPECIES STATS --}}
+                {{#if (eq item.type "species")}}
+                <div class="paper-section">
+                    <div class="paper-header">BIOLOGICAL PARAMETERS</div>
+                    <div class="form-group paper-row"><label>Base HP:</label><input type="number" name="system.hp" value="{{system.hp}}"/></div>
+                    <div class="form-group paper-row">
+                        <label>Movement (Close/Rush):</label>
+                        <div class="flexrow"><input type="number" name="system.move.closing" value="{{system.move.closing}}"/> / <input type="number" name="system.move.rushing" value="{{system.move.rushing}}"/></div>
+                    </div>
+                    <div class="stat-limits-grid">
+                        <div class="limit-box"><label>STR (Min/Max)</label><div class="flexrow"><input type="number" name="system.stats.str.min" value="{{system.stats.str.min}}"/>-<input type="number" name="system.stats.str.max" value="{{system.stats.str.max}}"/></div></div>
+                        <div class="limit-box"><label>DEX (Min/Max)</label><div class="flexrow"><input type="number" name="system.stats.dex.min" value="{{system.stats.dex.min}}"/>-<input type="number" name="system.stats.dex.max" value="{{system.stats.dex.max}}"/></div></div>
+                        <div class="limit-box"><label>KNOW (Min/Max)</label><div class="flexrow"><input type="number" name="system.stats.know.min" value="{{system.stats.know.min}}"/>-<input type="number" name="system.stats.know.max" value="{{system.stats.know.max}}"/></div></div>
+                        <div class="limit-box"><label>CONC (Min/Max)</label><div class="flexrow"><input type="number" name="system.stats.conc.min" value="{{system.stats.conc.min}}"/>-<input type="number" name="system.stats.conc.max" value="{{system.stats.conc.max}}"/></div></div>
+                        <div class="limit-box"><label>CHA (Min/Max)</label><div class="flexrow"><input type="number" name="system.stats.cha.min" value="{{system.stats.cha.min}}"/>-<input type="number" name="system.stats.cha.max" value="{{system.stats.cha.max}}"/></div></div>
+                        <div class="limit-box"><label>COOL (Min/Max)</label><div class="flexrow"><input type="number" name="system.stats.cool.min" value="{{system.stats.cool.min}}"/>-<input type="number" name="system.stats.cool.max" value="{{system.stats.cool.max}}"/></div></div>
                     </div>
                 </div>
                 {{/if}}
-            </div>
-            {{/if}}
 
-            {{!-- SKILL / TRAIT SPECIFIC --}}
-            {{#if (or (eq item.type "skill") (eq item.type "trait"))}}
-            <div class="academic-paper">
-                <div class="form-group line-item">
-                    <label>Related Stat:</label>
-                    <select name="system.stat">
-                        {{selectOptions config.stats selected=system.stat}}
-                    </select>
-                </div>
-                <div class="form-group line-item">
-                    <label>XP Cost:</label>
-                    <input type="number" name="system.xpCost" value="{{system.xpCost}}"/>
-                </div>
-                <div class="academic-note">
-                    Official SLA Industries Training Manual v.902
-                </div>
-            </div>
-            {{/if}}
-
-            {{!-- EBB / DISCIPLINE SPECIFIC --}}
-            {{#if (or (eq item.type "ebbFormula") (eq item.type "discipline"))}}
-            <div class="spectral-container">
-                <div class="form-group glow-input">
-                    <label>Flux Cost</label>
-                    <input type="number" name="system.cost" value="{{system.cost}}"/>
-                </div>
-                {{#if (eq item.type "ebbFormula")}}
-                <div class="form-group glow-input">
-                    <label>Formula Rating (FR)</label>
-                    <input type="number" name="system.formulaRating" value="{{system.formulaRating}}"/>
-                </div>
-                <div class="form-group glow-input">
-                    <label>Discipline</label>
-                    <select name="system.discipline">
-                        {{selectOptions config.disciplineSkills selected=system.discipline}}
-                    </select>
+                {{!-- PACKAGE REQS --}}
+                {{#if (eq item.type "package")}}
+                <div class="paper-section">
+                    <div class="paper-header">PREREQUISITES (Min Stat)</div>
+                    <div class="stat-limits-grid">
+                        <div class="limit-box"><label>STR</label><input type="number" name="system.requirements.str" value="{{system.requirements.str}}"/></div>
+                        <div class="limit-box"><label>DEX</label><input type="number" name="system.requirements.dex" value="{{system.requirements.dex}}"/></div>
+                        <div class="limit-box"><label>KNOW</label><input type="number" name="system.requirements.know" value="{{system.requirements.know}}"/></div>
+                        <div class="limit-box"><label>CONC</label><input type="number" name="system.requirements.conc" value="{{system.requirements.conc}}"/></div>
+                        <div class="limit-box"><label>CHA</label><input type="number" name="system.requirements.cha" value="{{system.requirements.cha}}"/></div>
+                        <div class="limit-box"><label>COOL</label><input type="number" name="system.requirements.cool" value="{{system.requirements.cool}}"/></div>
+                    </div>
                 </div>
                 {{/if}}
+
+                {{!-- SKILL GRANTING --}}
+                <div class="paper-section">
+                    <div class="paper-header">GRANTED SKILLS & TRAITS</div>
+                    <div class="drop-zone skill-grant-area">
+                        {{#each system.skills as |skill index|}}
+                            <div class="granted-skill-chip">
+                                <span class="skill-name">{{skill.name}} ({{skill.type}})</span>
+                                <a class="delete-grant" data-index="{{index}}" title="Remove"><i class="fas fa-times"></i></a>
+                            </div>
+                        {{else}}
+                            <div class="empty-dossier-text">Drag & Drop Skills/Traits here to auto-grant them.</div>
+                        {{/each}}
+                    </div>
+                </div>
             </div>
             {{/if}}
 
         </div>
 
-        {{!-- DESCRIPTION TAB --}}
+        {{!-- DESCRIPTION --}}
         <div class="tab description" data-group="primary" data-tab="description">
             {{editor enrichedDescription target="system.description" button=true owner=owner editable=editable}}
         </div>


### PR DESCRIPTION
Introduces a new 'Office Dossier' visual theme and layout for species and package item sheets, including stat limits, prerequisites, and skill granting UI. Updates CSS for the new theme, enhances the item sheet template with new sections for species and package data, and bumps system version to 0.2.6-alpha.