### PR TITLE
Group and display skills by stat on actor sheet

### DIFF
--- a/css/sla-industries.css
+++ b/css/sla-industries.css
@@ -1218,3 +1218,18 @@
 .sla-sheet .tab[data-tab="biography"] .tox-edit-area {
     height: 100%;
 }
+
+/* ==========================================
+   18. SKILL LIST GROUPING
+   ========================================== */
+
+.skill-group-header td {
+    background: #333;
+    color: #39ff14; /* SLA Green */
+    font-weight: bold;
+    text-transform: uppercase;
+    font-size: 0.85em;
+    padding-left: 5px;
+    border-bottom: 1px solid #555;
+    letter-spacing: 1px;
+}

--- a/templates/partials/skills.hbs
+++ b/templates/partials/skills.hbs
@@ -1,32 +1,57 @@
-<div class="sla-panel">
-    {{!-- HEADER --}}
-    <div class="sla-header-bar">SKILLS</div>
+<div class="sla-panel full-height">
     
-    {{!-- LIST --}}
+    {{!-- HEADER --}}
+    <div class="sla-header-bar flexrow">
+        <span style="flex:1">SKILLS</span>
+        <a class="item-create" data-type="skill" title="Create Skill"><i class="fas fa-plus"></i></a>
+    </div>
+    
+    {{!-- SCROLLABLE LIST --}}
     <div class="scroll-list">
         <table class="sla-table">
             <thead>
                 <tr>
-                    <th style="text-align: left; padding-left: 5px;">NAME</th>
-                    <th style="width: 50px; text-align: center;">RANK</th>
-                    <th style="width: 50px; text-align: center;">BONUS</th>
-                    <th style="width: 40px;"></th>
+                    <th style="text-align: left; padding-left: 5px;">Name</th>
+                    <th style="width: 50px;">Rank</th>
+                    <th style="width: 50px;">Roll</th>
+                    <th style="width: 50px;"></th>
                 </tr>
             </thead>
             <tbody>
-                {{#each skills as |skill id|}}
-                <tr class="item" data-item-id="{{skill._id}}">
-                    <td class="item-name rollable" data-roll-type="skill" style="padding-left: 5px; font-weight: bold; cursor: pointer;">
-                        {{skill.name}} <i class="fas fa-dice-d20" style="font-size: 0.8em; opacity: 0.5;"></i>
-                    </td>
-                    <td><input type="number" value="{{skill.system.rank}}" readonly style="text-align: center; background: transparent; border: none; color: #eee;"/></td>
-                    <td><input type="number" value="{{skill.system.bonus}}" readonly style="text-align: center; background: transparent; border: none; color: #eee;"/></td>
-                    <td class="item-controls" style="text-align: center;">
-                        <a class="item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
-                        <a class="item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
-                    </td>
-                </tr>
+                {{#each skillsByStat as |group key|}}
+                    {{#if group.items.length}}
+                        {{!-- SECTION HEADER (e.g. STR) --}}
+                        <tr class="skill-group-header">
+                            <td colspan="4">{{group.label}}</td>
+                        </tr>
+
+                        {{!-- SKILL ROWS --}}
+                        {{#each group.items as |skill|}}
+                        <tr class="item" data-item-id="{{skill._id}}">
+                            <td class="item-name rollable" data-roll-type="item" style="font-weight: bold; color: #fff; padding-left: 10px;">
+                                {{skill.name}}
+                            </td>
+                            <td style="text-align: center;">{{skill.system.rank}}</td>
+                            <td style="text-align: center;">
+                                <a class="rollable" data-roll-type="skill" title="Roll Skill"><i class="fas fa-dice-d20"></i></a>
+                            </td>
+                            <td class="item-controls">
+                                <a class="item-edit" title="Edit Skill"><i class="fas fa-edit"></i></a>
+                                <a class="item-delete" title="Delete Skill"><i class="fas fa-trash"></i></a>
+                            </td>
+                        </tr>
+                        {{/each}}
+                    {{/if}}
                 {{/each}}
+
+                {{!-- EMPTY STATE --}}
+                {{#unless (or skillsByStat.str.items.length skillsByStat.dex.items.length skillsByStat.know.items.length skillsByStat.conc.items.length skillsByStat.cha.items.length skillsByStat.cool.items.length)}}
+                    <tr>
+                        <td colspan="4" style="text-align: center; color: #555; font-style: italic; padding: 10px;">
+                            No skills learned.
+                        </td>
+                    </tr>
+                {{/unless}}
             </tbody>
         </table>
     </div>


### PR DESCRIPTION
Skills are now grouped by their associated stat (e.g., STR, DEX, etc.) in the actor sheet UI. The data preparation logic in actor-sheet.mjs was updated to categorize and sort skills into stat-based groups, and the skills.hbs template was refactored to render these groups with section headers. Additional UI improvements include a clearer empty state and a more accessible skill creation button. New CSS styles were added for group headers.