### PR TITLE
Refactor and enhance item sheet themes and actor sheet layout

### DIFF
--- a/css/sla-industries.css
+++ b/css/sla-industries.css
@@ -4,7 +4,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@400;600;700&display=swap');
 
 /* ==========================================
-   1. GLOBAL VARIABLES & WINDOW (Fixed Layout Lockdown)
+   1. GLOBAL VARIABLES & WINDOW
    ========================================== */
 :root {
     --sla-bg-dark: #1a1a25;   
@@ -18,42 +18,43 @@
     --sla-radius: 4px;
 }
 
-/* 1. Target the Foundry Window Wrapper */
-.sla-sheet.window-content,
-.app.window-app .window-content {
+/* ACTOR SHEET WRAPPER (Dark Theme) */
+.sla-industries.sheet.actor .window-content {
     background-image: none !important; 
     background: var(--sla-bg-dark) !important;
     background-color: var(--sla-bg-dark) !important;
     color: var(--sla-text-light);
     font-family: var(--sla-font-mono);
     font-size: 13px;
-    
-    /* CRITICAL: Remove padding and scroll from the window frame */
     padding: 0 !important; 
     overflow: hidden !important; 
     border: 2px solid var(--sla-border); 
 }
 
-/* 2. Target the Form inside */
+/* FORM LAYOUT */
 form.sla-sheet {
     height: 100%;
     display: flex;
     flex-direction: column;
-    /* CRITICAL: Ensure the form never scrolls itself */
     overflow: hidden !important; 
     background: transparent !important; 
     padding: 5px; 
 }
 
+/* PADDING UTILITY */
+.sla-pad {
+    padding: 8px !important;
+}
+
 /* ==========================================
-   2. INPUTS (High Contrast Readability)
+   2. INPUTS (Global High Contrast)
    ========================================== */
 .sla-sheet input[type="text"],
 .sla-sheet input[type="number"],
 .sla-sheet select {
-    background: #000 !important;       /* Pitch Black Background */
-    color: #e0e0e0 !important;         /* Bright White/Grey Text */
-    border: 1px solid #555;            /* Visible Border */
+    background: #000;       
+    color: #e0e0e0;         
+    border: 1px solid #555;            
     border-radius: var(--sla-radius);
     height: 26px;
     padding: 1px 5px;
@@ -62,7 +63,7 @@ form.sla-sheet {
 
 .sla-sheet input:focus {
     box-shadow: 0 0 5px var(--sla-accent);
-    background: #111 !important;
+    background: #111;
 }
 
 .sla-sheet select {
@@ -71,12 +72,10 @@ form.sla-sheet {
 }
 
 /* ==========================================
-   3. HEADER LAYOUT (Stacked & Readable)
+   3. HEADER LAYOUT
    ========================================== */
-
-/* Main Header Box */
 .sla-sheet .sheet-header {
-	flex: 0 0 auto; /* Don't shrink */
+    flex: 0 0 auto;
     margin-bottom: 10px;
     border: 2px solid var(--sla-border);
     background: #111;
@@ -89,11 +88,12 @@ form.sla-sheet {
 }
 
 /* --- COLUMN 1: THE CARD (Left) --- */
+/* WIDENED: 70% to give more room for names/chips */
 .header-left {
-    flex: 0 0 60%; /* Fixed 60% width */
+    flex: 0 0 70%; 
     display: flex;
     flex-direction: column;
-    background: var(--sla-bg-panel); /* Dark Panel Color */
+    background: var(--sla-bg-panel);
     border-right: 2px solid var(--sla-border);
     padding: 8px;
     color: #e0e0e0;
@@ -102,11 +102,11 @@ form.sla-sheet {
 .header-section-title {
     background: #111;
     color: var(--sla-accent);
-    font-family: var(--sla-font-header); /* Josefin Sans */
+    font-family: var(--sla-font-header);
     font-weight: 700;
     text-transform: uppercase;
     padding: 4px;
-    margin: -8px -8px 8px -8px; /* Touch edges */
+    margin: -8px -8px 8px -8px; 
     border-bottom: 1px solid var(--sla-border);
     text-align: center;
     letter-spacing: 1px;
@@ -118,7 +118,6 @@ form.sla-sheet {
     gap: 6px; 
 }
 
-/* Field Rows */
 .form-group {
     display: flex;
     align-items: center;
@@ -129,17 +128,15 @@ form.sla-sheet {
 .form-group label.label-bold {
     flex: 0 0 70px; 
     font-weight: 700;
-    font-family: var(--sla-font-header); /* Josefin Sans */
-    color: #aaa;    
+    font-family: var(--sla-font-header);
+    color: #ccc; 
     font-size: 13px;
     text-transform: uppercase;
 }
 
-.form-group input {
-    flex: 1; 
-}
+.form-group input { flex: 1; }
 
-/* Chips */
+/* CHIPS (Header) */
 .chip {
     flex: 1;
     display: flex;
@@ -151,7 +148,7 @@ form.sla-sheet {
     border-radius: var(--sla-radius);
     height: 30px;
 }
-/* FIX: Chip Image Stability */
+
 .chip img {
     flex: 0 0 24px;       
     width: 24px;          
@@ -165,11 +162,10 @@ form.sla-sheet {
 .chip-name { color: #fff; font-weight: bold; flex: 1; }
 .chip-delete { color: #d00; cursor: pointer; padding: 0 5px; }
 .chip-placeholder { 
-    flex: 1; background: #111; color: #777; border: 1px dashed #555; 
+    flex: 1; background: #111; color: #888; border: 1px dashed #555; 
     text-align: center; font-style: italic; height: 30px; display: flex; align-items: center; justify-content: center;
 }
 
-/* Bottom Bar (LAD/SCL) */
 .header-bottom-bar {
     display: flex;
     justify-content: space-between;
@@ -207,11 +203,13 @@ form.sla-sheet {
 .finance-box {
     flex: 1;
     background: var(--sla-bg-panel);
-    padding: 8px;
+    padding: 0; 
     color: #e0e0e0;
+    display: flex;
+    flex-direction: column;
 }
 .finance-header {
-    color: #aaa;
+    color: #ccc; 
     font-weight: 700;
     font-family: var(--sla-font-header);
     font-size: 11px;
@@ -226,25 +224,26 @@ form.sla-sheet {
     border-bottom: 2px solid var(--sla-accent);
     margin-bottom: 5px;
 }
-.finance-body label { font-size: 0.8em; color: #aaa; margin-bottom: 2px; display: block; font-family: var(--sla-font-header); font-weight: 700;}
+/* Ensure Finance inputs don't touch edges */
+.finance-box .finance-body input {
+    width: 98% !important;
+    margin: 0 auto !important;
+    display: block !important;
+}
 
 
 /* ==========================================
-   4. STATS STRIP (Dark Dystopian Fix)
+   4. STATS STRIP
    ========================================== */
-
-/* 1. The Main Container Strip */
 .sla-sheet .stats-strip-container {
-    flex: 0 0 auto; /* Don't shrink */
-	margin-top: 5px;
+    flex: 0 0 auto;
+    margin-top: 5px;
     padding: 5px;
     background-color: var(--sla-bg-panel) !important; 
-    background-image: none !important;
     border-top: 2px solid var(--sla-border);
     border-bottom: 2px solid var(--sla-border);
 }
 
-/* 2. The Grid Layout */
 .stats-matrix, .stats-grid { 
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 100px; 
@@ -258,7 +257,6 @@ form.sla-sheet {
     gap: 5px;
 }
 
-/* 3. Rating Headers */
 .rating-header, .rating-block {
     display: flex;
     justify-content: space-between;
@@ -278,7 +276,7 @@ form.sla-sheet {
 .rating-label { 
     font-weight: 700; 
     font-family: var(--sla-font-header);
-    color: #999; 
+    color: #bbb; 
     font-size: 0.8em;
     background: transparent !important; 
 }
@@ -289,7 +287,6 @@ form.sla-sheet {
     font-weight: bold; font-size: 1.4em; text-shadow: none;
 }
 
-/* 4. Attribute Boxes */
 .stat-box, .stat-row {
     display: flex;
     align-items: center;
@@ -323,16 +320,13 @@ form.sla-sheet {
     color: #fff !important;
 }
 .stat-box .rollable, .stat-row .rollable { 
-    color: #555; cursor: pointer; 
+    color: #777; cursor: pointer; 
 }
 .stat-box .rollable:hover, .stat-row .rollable:hover { 
     color: var(--sla-accent); 
 }
 
-/* 5. Side Stats */
-.side-col { 
-    display: flex; flex-direction: column; gap: 5px; justify-content: space-between; 
-}
+.side-col { display: flex; flex-direction: column; gap: 5px; justify-content: space-between; }
 .side-box, .secondary-box { 
     background: #000 !important; 
     border: 1px solid var(--sla-border); 
@@ -340,7 +334,7 @@ form.sla-sheet {
     border-radius: var(--sla-radius);
 }
 .side-box label, .secondary-box label { 
-    display: block; color: #999; font-size: 0.7em; 
+    display: block; color: #bbb; font-size: 0.7em; 
     font-family: var(--sla-font-header);
     font-weight: 700; 
 }
@@ -350,7 +344,6 @@ form.sla-sheet {
     border: none !important;
 }
 
-/* --- Initiative Button Styling --- */
 .side-box.init, .secondary-box.init { 
     background: var(--sla-accent) !important;
     border: 1px solid var(--sla-accent);
@@ -374,64 +367,45 @@ form.sla-sheet {
     text-shadow: none;
 }
 
-
 /* ==========================================
-   5. MAIN LAYOUT (Scroll Container Fix)
+   5. MAIN LAYOUT
    ========================================== */
 .sla-sheet .sheet-body {
-    flex: 1; /* Fill the remaining window space */
-    
-    /* This creates the scroll frame */
+    flex: 1;
     overflow-y: auto !important; 
     overflow-x: hidden;
-    min-height: 0; /* Critical for Flexbox scrolling */
-    
+    min-height: 0; 
     padding: 5px; 
     padding-right: 5px; 
-    
-    /* Scrollbar Aesthetics */
     scrollbar-width: thin;
     scrollbar-color: var(--sla-accent) #000;
 }
 
-/* 1. THE TAB SWITCHING LOGIC (Must come first) */
-.sla-sheet .sheet-body .tab {
-    display: none; /* Hide by default */
-}
+.sla-sheet .sheet-body .tab { display: none; }
+.sla-sheet .sheet-body .tab.active { display: block; }
 
-.sla-sheet .sheet-body .tab.active {
-    display: block; /* Show ONLY if it has the 'active' class */
-}
-
-/* 2. THE HEIGHT FIX (Without breaking visibility) */
-/* We target the active tab and inner containers to ensure they grow */
 .sla-sheet .tab.active,
 .sla-sheet .tab .flexcol,
 .sla-sheet .tab .full-height {
     height: auto !important;
     min-height: min-content !important;
     overflow: visible !important;
-    
 }
 
-/* --- LAYOUT GRIDS --- */
+/* MAIN SPLIT RATIO */
+/* Adjusted: 2.2fr (Left/Skills) / 1fr (Right/Combat) */
 .sla-sheet .main-split {
     display: grid;
-    grid-template-columns: 1.6fr 1fr; 
+    grid-template-columns: 2.2fr 1fr; 
     gap: 10px;
     height: auto !important; 
     align-items: start; 
 }
 
-.sla-sheet .left-col, 
-.sla-sheet .right-col {
-    display: flex;
-    flex-direction: column;
-    height: auto !important;
-    min-width: 0; 
+.sla-sheet .left-col, .sla-sheet .right-col {
+    display: flex; flex-direction: column; height: auto !important; min-width: 0; 
 }
 
-/* --- PANELS --- */
 .sla-sheet .sla-panel {
     display: flex; flex-direction: column;
     width: 100%;
@@ -439,8 +413,8 @@ form.sla-sheet {
     border: 1px solid var(--sla-border);
     overflow: hidden;
     border-radius: var(--sla-radius);
-    flex: 0 0 auto; /* Don't squash panels */
-    margin-bottom: 5px; /* Add spacing between stacked panels */
+    flex: 0 0 auto; 
+    margin-bottom: 5px; 
 }
 
 .sla-sheet .sla-header-bar {
@@ -452,91 +426,43 @@ form.sla-sheet {
     border-bottom: 1px solid var(--sla-border);
 }
 
-/* Lists inside panels can auto-scroll if they get massive, 
-   but usually we want the page to scroll */
-.sla-sheet .scroll-list {
-    overflow-y: visible; 
-    height: auto;
-    padding: 0;
-}
+.sla-sheet .scroll-list { overflow-y: visible; height: auto; padding: 0; }
 
 /* ==========================================
-   6. TABS & EDITORS (Height Fix)
+   6. TABS & EDITORS
    ========================================== */
 .sla-sheet .sheet-tabs {
     display: flex; 
     border-bottom: 2px solid var(--sla-accent); 
     margin-bottom: 5px; 
     background: #1a1a25;
-    flex: 0 0 auto; /* Don't shrink */
+    flex: 0 0 auto; 
 }
 .sla-sheet .sheet-tabs .item {
     padding: 5px 15px; 
-    color: #aaa; 
+    color: #bbb; 
     font-family: var(--sla-font-header);
     font-weight: 700; 
     text-transform: uppercase;
     border-right: 1px solid #333; 
     cursor: pointer;
 }
-.sla-sheet .sheet-tabs .item:hover { 
-    color: var(--sla-text-light); 
-    background: rgba(255,255,255,0.05); 
-}
-.sla-sheet .sheet-tabs .item.active { 
-    color: #000; 
-    background: var(--sla-accent); 
-}
+.sla-sheet .sheet-tabs .item:hover { color: var(--sla-text-light); background: rgba(255,255,255,0.05); }
+.sla-sheet .sheet-tabs .item.active { color: #000; background: var(--sla-accent); }
 
-/* CRITICAL FIX: height: auto allows the tab to grow tall, triggering the body scroll */
-.sla-sheet .tab { 
-    display: none; 
-    height: auto !important; 
-    overflow: visible; 
+/* TAB EDITOR FIX (Min-Height 700px) */
+.sla-industries.item .tab.active[data-tab="description"] {
+    display: flex !important;      
+    flex-direction: column;
+    height: 100%;
+    min-height: 700px;
 }
-.sla-sheet .tab.active { 
-    display: block; 
+.sla-industries.item .tab[data-tab="description"] .editor {
+    flex: 1; height: 100%; display: flex; flex-direction: column;
 }
-
-/* Editor Containers */
-.sla-sheet .editor-container {
-    border: 1px solid #444; background: rgba(0, 0, 0, 0.2);
-    display: flex; flex-direction: column; position: relative;
-    min-height: 300px; /* Ensure editor has size even if empty */
-}
-
-/* Ensure editor contents fit */
-.sla-sheet .tab[data-tab="biography"] .editor-container .editor,
-.sla-sheet .tab[data-tab="biography"] .tox-edit-area {
-    min-height: 300px;
-}
-.sla-sheet .tab[data-tab="biography"] .editor-content {
-    color: #e0e0e0; font-family: "Arial", sans-serif; line-height: 1.4;
-    padding: 5px;
-}
-.sla-sheet .editor-edit {
-    background: #222; color: #39ff14; border: 1px solid #39ff14; padding: 2px 6px;
-    border-radius: 4px; position: absolute; top: 5px; right: 5px; z-index: 10;
-}
-
-/* Editor Containers */
-.sla-sheet .editor-container {
-    border: 1px solid #444; background: rgba(0, 0, 0, 0.2);
-    display: flex; flex-direction: column; position: relative;
-}
-.sla-sheet .editor-container.appearance,
-.sla-sheet .editor-container.biography { flex: 1; min-height: 250px; }
-.sla-sheet .editor-container.notes { height: 100%; min-height: 500px; }
-
-.sla-sheet .tab[data-tab="biography"] .editor-container .editor {
-    flex: 1; height: 100%; min-height: 0; border: none; background: transparent; padding: 5px;
-}
-.sla-sheet .tab[data-tab="biography"] .editor-content {
-    height: 100%; color: #e0e0e0; font-family: "Arial", sans-serif; line-height: 1.4; overflow-y: auto;
-}
-.sla-sheet .editor-edit {
-    background: #222; color: #39ff14; border: 1px solid #39ff14; padding: 2px 6px;
-    border-radius: 4px; position: absolute; top: 5px; right: 5px; z-index: 10;
+.sla-industries.item .tab[data-tab="description"] .tox-edit-area,
+.sla-industries.item .tab[data-tab="description"] .editor-content {
+    flex: 1; height: 100%; min-height: 600px; overflow-y: auto;
 }
 
 /* ==========================================
@@ -551,7 +477,6 @@ form.sla-sheet {
 .item-chip .chip-delete { color: #555; padding: 0 8px; cursor: pointer; }
 .item-chip .chip-delete:hover { color: #f00; }
 
-/* Item Controls in Lists */
 .sla-sheet .item-controls { display: flex; gap: 5px; min-width: 40px; justify-content: center; }
 .sla-sheet .item-controls a { width: 18px; text-align: center; color: #aaa; cursor: pointer; }
 .sla-sheet .item-controls .item-edit:hover { color: #fff; }
@@ -567,779 +492,337 @@ form.sla-sheet {
 .sla-dialog button:hover { background: #39ff14; color: #000; }
 
 /* ==========================================
-   9. UI POLISH (ROUNDED & COMPACT)
+   9. UI POLISH
    ========================================== */
-
-/* The Container Box */
 .sla-box {
     background: rgba(0, 0, 0, 0.2);
     border: 1px solid #444;
-    border-radius: 8px; /* Rounded Corners */
+    border-radius: 8px; 
     padding: 8px;
     margin-bottom: 8px;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
+    display: flex; flex-direction: column; gap: 4px;
 }
-
-/* Header for the box */
 .sla-box-header {
-    font-size: 0.75em;
-    font-weight: 700;
-    font-family: var(--sla-font-header);
-    color: #888;
-    text-transform: uppercase;
-    border-bottom: 1px solid #333;
-    margin-bottom: 5px;
-    padding-bottom: 2px;
-    letter-spacing: 1px;
+    font-size: 0.75em; font-weight: 700; font-family: var(--sla-font-header);
+    color: #bbb; text-transform: uppercase; border-bottom: 1px solid #333;
+    margin-bottom: 5px; padding-bottom: 2px; letter-spacing: 1px;
 }
-
-/* Mini Input (2 digits) */
 .sla-input-mini {
-    width: 45px !important;
-    text-align: center;
-    border-radius: 4px !important;
-    background: #111 !important;
-    color: #fff !important;
-    border: 1px solid #555 !important;
-    height: 24px !important;
-    font-weight: bold;
+    width: 45px !important; text-align: center; border-radius: 4px !important;
+    background: #111 !important; color: #fff !important;
+    border: 1px solid #555 !important; height: 24px !important; font-weight: bold;
 }
-
-/* Flex rows for side-by-side stats */
 .compact-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-size: 0.9em;
-    color: #ccc;
-    height: 26px;
+    display: flex; justify-content: space-between; align-items: center;
+    font-size: 0.9em; color: #ccc; height: 26px;
 }
 
 /* ==========================================
-   10. WOUNDS & CONDITIONS (Styled like Stats)
+   10. WOUNDS & CONDITIONS
    ========================================== */
-
-/* Section Headers (Wounds / Conditions) */
 .wound-section-title {
-    font-weight: 700;
-    font-family: var(--sla-font-header);
-    color: var(--sla-accent);
-    text-transform: uppercase;
+    font-weight: 700; font-family: var(--sla-font-header);
+    color: var(--sla-accent); text-transform: uppercase;
     border-bottom: 1px solid var(--sla-border);
-    margin-bottom: 5px;
-    padding-bottom: 2px;
-    font-size: 0.85em;
-    letter-spacing: 1px;
+    margin-bottom: 5px; padding-bottom: 2px; font-size: 0.85em; letter-spacing: 1px;
 }
-
-/* --- WOUNDS GRID --- */
 .wound-list {
-    display: grid;
-    grid-template-columns: 1fr 1fr; /* Two Columns */
-    gap: 8px; /* Increased gap */
-    margin-bottom: 10px;
+    display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 10px;
 }
-
-/* Styled to match Stat Boxes */
 .wound-entry {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: #000; /* Black Background */
-    border: 1px solid var(--sla-border); /* Standard Border */
-    padding: 4px 8px;
-    border-radius: var(--sla-radius);
+    display: flex; justify-content: space-between; align-items: center;
+    background: #000; border: 1px solid var(--sla-border); padding: 4px 8px; border-radius: var(--sla-radius);
 }
+.wound-entry label { font-size: 0.9em; font-weight: bold; color: var(--sla-text-light); cursor: pointer; }
+.wound-entry input[type="checkbox"] { height: 16px; width: 16px; margin: 0; cursor: pointer; accent-color: var(--sla-accent); }
 
-.wound-entry label {
-    font-size: 0.9em;
-    font-weight: bold;
-    color: var(--sla-text-light);
-    cursor: pointer;
-}
-
-/* Custom Checkbox Alignment */
-.wound-entry input[type="checkbox"] {
-    height: 16px;
-    width: 16px;
-    margin: 0;
-    cursor: pointer;
-    accent-color: var(--sla-accent); /* Makes the checkmark orange/system color */
-}
-
-/* --- CONDITIONS GRID --- */
 .condition-grid {
-    display: flex;
-    justify-content: space-between; /* Spread them out */
-    flex-wrap: wrap; /* Allow wrapping if resizing */
-    gap: 8px; /* Better spacing between icons */
-    padding-top: 10px;
-    border-top: 1px solid var(--sla-border); /* Separator line */
-    margin-top: 5px;
+    display: flex; justify-content: space-between; flex-wrap: wrap; gap: 8px; padding-top: 10px; border-top: 1px solid var(--sla-border); margin-top: 5px;
 }
-
 .condition-toggle {
-    background: #1a1a25; /* Dark background */
-    border: 1px solid var(--sla-border);
-    width: 40px;  /* Larger touch target */
-    height: 40px; /* Larger touch target */
-    border-radius: var(--sla-radius);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: #555; /* Dimmed when inactive */
-    cursor: pointer;
-    transition: all 0.2s ease;
-    font-size: 1.5em; /* Larger Icon */
+    background: #1a1a25; border: 1px solid var(--sla-border);
+    width: 40px; height: 40px; border-radius: var(--sla-radius);
+    display: flex; align-items: center; justify-content: center;
+    color: #555; cursor: pointer; transition: all 0.2s ease; font-size: 1.5em; 
 }
-
-.condition-toggle:hover {
-    border-color: var(--sla-text-light);
-    color: var(--sla-text-light);
-    background: #222;
-}
-
-/* Active State (The Glow) */
+.condition-toggle:hover { border-color: var(--sla-text-light); color: var(--sla-text-light); background: #222; }
 .condition-toggle.active {
-    background: #333;
-    color: var(--sla-accent); 
-    border-color: var(--sla-accent);
-    box-shadow: 0 0 8px var(--sla-accent-faint);
-    text-shadow: 0 0 5px var(--sla-accent);
+    background: #333; color: var(--sla-accent); border-color: var(--sla-accent);
+    box-shadow: 0 0 8px var(--sla-accent-faint); text-shadow: 0 0 5px var(--sla-accent);
 }
+.condition-toggle[data-condition="bleeding"].active { color: #ff4444; border-color: #ff4444; box-shadow: 0 0 8px rgba(255,68,68,0.4); text-shadow: 0 0 5px #ff4444; }
+.condition-toggle[data-condition="burning"].active { color: #ffaa00; border-color: #ffaa00; box-shadow: 0 0 8px rgba(255,170,0,0.4); text-shadow: 0 0 5px #ffaa00; }
+.condition-toggle[data-condition="stunned"].active { color: #ffff00; border-color: #ffff00; box-shadow: 0 0 8px rgba(255,255,0,0.4); text-shadow: 0 0 5px #ffff00; }
+.condition-toggle[data-condition="immobile"].active { color: #00ccff; border-color: #00ccff; box-shadow: 0 0 8px rgba(0,204,255,0.4); text-shadow: 0 0 5px #00ccff; }
 
-/* Specific Colors for Conditions */
-.condition-toggle[data-condition="bleeding"].active { 
-    color: #ff4444; border-color: #ff4444; box-shadow: 0 0 8px rgba(255,68,68,0.4); text-shadow: 0 0 5px #ff4444; 
-}
-.condition-toggle[data-condition="burning"].active { 
-    color: #ffaa00; border-color: #ffaa00; box-shadow: 0 0 8px rgba(255,170,0,0.4); text-shadow: 0 0 5px #ffaa00; 
-}
-.condition-toggle[data-condition="stunned"].active { 
-    color: #ffff00; border-color: #ffff00; box-shadow: 0 0 8px rgba(255,255,0,0.4); text-shadow: 0 0 5px #ffff00; 
-}
-.condition-toggle[data-condition="immobile"].active { 
-    color: #00ccff; border-color: #00ccff; box-shadow: 0 0 8px rgba(0,204,255,0.4); text-shadow: 0 0 5px #00ccff; 
-}
-
-/* Critical is read-only */
-.condition-read-only {
-    width: 40px; height: 40px; /* Match toggle size */
-    display: flex; align-items: center; justify-content: center; 
-    border-radius: var(--sla-radius); 
-    background: #1a1a25; border: 1px solid var(--sla-border); color: #555;
-    font-size: 1.5em;
-}
-.condition-read-only.active {
-    color: #ff0000; border-color: #ff0000; background: #300; animation: pulse 1s infinite;
+/* CRITICAL BUTTON (New Skull) */
+.condition-toggle[data-condition="critical"].active { 
+    color: #ff0000; 
+    border-color: #ff0000; 
+    box-shadow: 0 0 8px rgba(255, 0, 0, 0.5); 
+    text-shadow: 0 0 5px #ff0000; 
+    background: #330000 !important;
 }
 
 /* ==========================================
    11. EBB DISCIPLINES STYLING
    ========================================== */
-
-/* Parent Row (The Discipline) */
-.discipline-row {
-    background-color: rgba(138, 43, 226, 0.15) !important; /* Purple Tint */
-    border-bottom: 1px solid #444;
-    border-top: 1px solid #444;
-}
-
-.discipline-row:hover {
-    background-color: rgba(138, 43, 226, 0.25) !important;
-}
-
-/* Child Row (The Formula) */
-.formula-row {
-    background-color: transparent !important;
-    border-bottom: 1px dotted #333;
-}
-
-.formula-row:hover {
-    background-color: rgba(255, 255, 255, 0.05) !important;
-}
-
-.formula-row:last-child {
-    border-bottom: none;
-}
-
-.formula-row .rollable:hover {
-    color: #fff !important;
-    text-shadow: 0 0 5px #8a2be2;
-}
+.discipline-row { background-color: rgba(138, 43, 226, 0.15) !important; border-bottom: 1px solid #444; border-top: 1px solid #444; }
+.discipline-row:hover { background-color: rgba(138, 43, 226, 0.25) !important; }
+.formula-row { background-color: transparent !important; border-bottom: 1px dotted #333; }
+.formula-row:hover { background-color: rgba(255, 255, 255, 0.05) !important; }
+.formula-row:last-child { border-bottom: none; }
+.formula-row .rollable:hover { color: #fff !important; text-shadow: 0 0 5px #8a2be2; }
 
 /* ==========================================
-   12. THREAT SHEET (NPC RESTORATION)
+   13. ITEM SHEET THEMES (Refactored)
    ========================================== */
 
-/* 1. Reset Container to Light Theme */
-.sla-sheet.threat-sheet.window-content {
-    background: #e8e8e8 !important; /* Light Grey Paper */
-    color: #000 !important;         /* Black Text */
-    font-family: "Georgia", serif;  /* Book Font */
-    padding: 0;
-    border: 3px solid #800;         /* Red Border */
-}
-
-.threat-header {
-    background: #880000; /* Deep Red */
-    padding: 5px;
-    border-bottom: 2px solid #000;
-    display: flex;
-    align-items: center;
-    height: 90px;
-}
-
-.threat-header input {
-    background: transparent !important;
-    border: none !important;
-    color: #fff !important;
-    font-family: "Arial", sans-serif;
-    font-weight: bold;
-    font-size: 1.8em;
-    text-transform: uppercase;
-    box-shadow: none !important;
-}
-
-.threat-img {
-    flex: 0 0 80px;
-    height: 80px;
-    width: 80px;
-    border: 2px solid #fff;
-    background: #000;
-    margin-left: 10px;
-}
-
-/* 3. Stat Table */
-.threat-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 10px;
-    border: 1px solid #000;
-    table-layout: fixed; 
-}
-
-/* Header Cells (STR, DEX, etc) */
-.threat-row-label th {
-    background: #222;
-    color: #fff;
-    font-weight: bold;
-    text-align: center;
-    padding: 2px;
-    border-right: 1px solid #555;
-    font-family: "Arial", sans-serif;
-    font-size: 0.8em;
-}
-.threat-row-label th:last-child {
-    border-right: none;
-}
-
-/* Data Cells (Inputs) */
-.threat-row-value td {
-    padding: 0;
-    border-right: 1px solid #ccc;
-}
-.threat-row-value td:last-child {
-    border-right: none;
-}
-
-/* Inputs inside cells */
-.threat-row-value input {
-    width: 100%;
-    background: #fff !important;
-    color: #000 !important;
-    border: none !important;
-    text-align: center;
-    font-weight: bold;
-    font-size: 1.1em;
-    height: 30px;
-    border-radius: 0;
-}
-
-/* 4. Derived Stats Row */
-.threat-derived {
-    gap: 5px;
-    margin-bottom: 10px;
-}
-
-.threat-box {
-    background: #fff;
-    border: 1px solid #000;
-    padding: 2px;
-    flex: 1;
-    text-align: center;
-}
-
-.threat-box label {
-    display: block;
-    background: #ccc;
-    font-weight: bold;
-    font-size: 0.7em;
-    margin-bottom: 2px;
-}
-
-.threat-box input {
-    background: transparent !important;
-    color: #000 !important;
-    border: none !important;
-    text-align: center;
-    font-weight: bold;
-}
-
-/* 5. Lists & Content */
-.threat-section-bar {
-    background: #333;
-    color: #fff;
-    padding: 2px 5px;
-    font-weight: bold;
-    text-transform: uppercase;
-    border-top: 1px solid #000;
-    font-size: 0.9em;
-}
-
-.threat-content-box {
-    background: #fff;
-    padding: 5px;
-    border: 1px solid #ccc;
-    min-height: 50px;
-    margin-bottom: 5px;
-}
-
-.threat-item {
-    padding: 2px;
-    border-bottom: 1px dashed #ccc;
-    align-items: center;
-    display: flex; 
-}
-
-/* FIX: Force Image Size */
-.threat-item img {
-    flex: 0 0 24px; 
-    width: 24px;
-    height: 24px;
-    object-fit: cover;
-    margin-right: 5px;
-    border: 1px solid #000;
-}
-
-.threat-item .item-name {
-    flex: 1;
-    color: #000;
-    cursor: pointer;
-}
-.threat-item .item-name:hover {
-    color: #a00;
-    text-shadow: none;
-}
-
-.threat-item .item-controls {
-    display: flex;
-    gap: 5px;
-}
-.threat-item .item-controls a {
-    color: #555;
-}
-.threat-item .item-controls a:hover {
-    color: #d00;
-}
-
-/* 6. Editor Fix for White Paper */
-.threat-sheet .editor {
-    height: 100%;
-}
-.threat-sheet .editor-content {
-    color: #000 !important;
-    font-family: "Georgia", serif;
-}
-.threat-sheet .editor-edit {
-    background: #eee;
-    color: #000;
-    border: 1px solid #000;
-}
-
-/* ==========================================
-   13. ITEM SHEET THEMES
-   ========================================== */
-
-/* --- A. CATALOGUE THEME (Weapons, Gear, Armor, Drugs) --- */
-.item.weapon-theme, .item.item-theme, .item.armor-theme, .item.drug-theme, .item.magazine-theme {
-    background: #e0e0e0; /* Light Grey Industrial */
+/* A. BASE WHITE THEME (Applies to ALL Items by default) */
+.item .window-content {
+    background: #e0e0e0 !important; 
     border: 4px solid #333;
     font-family: "Arial", sans-serif;
     color: #111;
 }
-
-.item.weapon-theme .sheet-header, .item.item-theme .sheet-header, .item.armor-theme .sheet-header, .item.drug-theme .sheet-header, .item.magazine-theme .sheet-header {
-    background: #222;
-    color: #fff;
-    border-bottom: 4px solid #f90; /* Industrial Orange Accent */
+.item .sheet-header {
+    background: #222 !important;
+    color: #fff !important;
+    border-bottom: 4px solid #f90;
     padding: 10px;
 }
-
-.item.weapon-theme input, .item.item-theme input, 
-.item.armor-theme input, .item.drug-theme input {
-    background: #fff;
-    border: 1px solid #999;
-    color: #000;
+.item input {
+    background: #fff !important; 
+    border: 1px solid #999 !important;
+    color: #000 !important;
     font-family: "Courier New", monospace;
-}
-
-.catalogue-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 10px;
-    padding: 10px;
-    background: #ccc;
-    border: 1px solid #999;
-}
-
-.catalogue-grid label {
     font-weight: bold;
-    text-transform: uppercase;
-    font-size: 0.8em;
-    color: #444;
 }
 
-/* --- B. ACADEMIC THEME (Skills, Traits) --- */
-.item.skill-theme, .item.trait-theme {
-    background: #fdfbf7; /* Cream Paper */
+/* B. ACADEMIC THEME OVERRIDE (Skills, Traits) */
+.item.skill .window-content, 
+.item.trait .window-content {
+    background: #fdfbf7 !important; 
     color: #222;
     font-family: "Georgia", serif;
     border: 1px solid #aaa;
-    box-shadow: 2px 2px 10px rgba(0,0,0,0.1);
 }
-
-.item.skill-theme .sheet-header, .item.trait-theme .sheet-header {
-    background: transparent;
-    border-bottom: 2px solid #000;
-    color: #000;
-}
-
-.item.skill-theme input, .item.trait-theme input {
-    background: transparent;
+.item.skill .sheet-header, 
+.item.trait .sheet-header {
+    background: transparent !important;
     border: none;
-    border-bottom: 1px dotted #000;
-    color: #000;
+    border-bottom: 2px solid #000;
+    color: #000 !important;
+}
+.item.skill input, 
+.item.trait input {
+    background: transparent !important;
+    border: none !important;
+    border-bottom: 1px dotted #000 !important;
+    color: #000 !important;
     font-family: "Georgia", serif;
     font-style: italic;
+    font-weight: bold;
 }
+.academic-paper { padding: 10px; }
+.academic-paper .line-item { display: flex; justify-content: space-between; border-bottom: 1px solid #ddd; padding: 5px 0; }
+.academic-note { margin-top: 20px; font-size: 0.7em; text-align: center; color: #888; border-top: 1px solid #000; padding-top: 5px; }
 
-.academic-paper {
-    padding: 10px;
-}
+/* ==========================================
+   13-C. SPECTRAL THEME (Ebb, Discipline)
+   ========================================== */
 
-.academic-paper .line-item {
-    display: flex;
-    justify-content: space-between;
-    border-bottom: 1px solid #ddd;
-    padding: 5px 0;
-}
-
-.academic-note {
-    margin-top: 20px;
-    font-size: 0.7em;
-    text-align: center;
-    color: #888;
-    border-top: 1px solid #000;
-    padding-top: 5px;
-}
-
-/* --- C. SPECTRAL THEME (Ebb, Discipline) --- */
-.item.ebbFormula-theme, .item.discipline-theme {
-    background: #0a0011; /* Deep Void */
-    color: #d8bfff; /* Pale Purple */
+/* 1. Background & Window */
+.item.ebbFormula .window-content, 
+.item.ebbformula .window-content, 
+.item.discipline .window-content {
+    background-image: none !important; 
+    background: #0a0011 !important;    
+    background-color: #0a0011 !important;
+    color: #d8bfff !important;
     font-family: "Roboto", sans-serif;
     border: 2px solid #8a2be2;
-    box-shadow: 0 0 15px rgba(138, 43, 226, 0.5);
 }
 
-.item.ebbFormula-theme .sheet-header, .item.discipline-theme .sheet-header {
-    background: linear-gradient(90deg, #1a002a, #30004a);
+/* Header */
+.item.ebbFormula .sheet-header, 
+.item.ebbformula .sheet-header, 
+.item.discipline .sheet-header {
+    background: linear-gradient(90deg, #1a002a, #30004a) !important;
     border-bottom: 1px solid #8a2be2;
 }
 
-.item.ebbFormula-theme input, .item.discipline-theme input,
-.item.ebbFormula-theme select, .item.discipline-theme select {
-    background: rgba(0,0,0,0.5);
-    border: 1px solid #8a2be2;
-    color: #fff;
+/* 2. Inputs & Glows */
+.item.ebbFormula input, .item.ebbformula input,
+.item.discipline input,
+.item.ebbFormula select, .item.ebbformula select,
+.item.discipline select {
+    background: rgba(0,0,0,0.5) !important;
+    border: 1px solid #8a2be2 !important;
+    color: #fff !important;
     text-shadow: 0 0 5px #8a2be2;
 }
+.spectral-container { padding: 10px; }
+.glow-input { margin-bottom: 10px; padding: 5px; border: 1px solid rgba(138, 43, 226, 0.3); background: rgba(138, 43, 226, 0.05); }
+.glow-input label { color: #a855f7; text-transform: uppercase; font-size: 0.8em; letter-spacing: 1px; }
 
-.spectral-container {
-    padding: 10px;
+
+/* ==========================================
+   FIX: EBB DISCIPLINE DROP ZONE (Direct Targeting)
+   ========================================== */
+
+/* 1. The Container (The Box) */
+.discipline-drop-zone {
+    display: flex !important;
+    flex-direction: row !important;
+    flex-wrap: nowrap !important;
+    align-items: center !important;
+    justify-content: center !important;
+    
+    border: 1px solid #8a2be2 !important; 
+    background: rgba(42, 0, 58, 0.6) !important;
+    border-radius: 4px !important;
+    padding: 2px 8px !important;
+    
+    min-height: 32px !important;
+    width: auto !important;
+    max-width: 100%; 
+    cursor: pointer;
+    box-sizing: border-box !important;
 }
 
-.glow-input {
-    margin-bottom: 10px;
-    padding: 5px;
-    border: 1px solid rgba(138, 43, 226, 0.3);
-    background: rgba(138, 43, 226, 0.05);
+.discipline-drop-zone:hover {
+    background: rgba(138, 43, 226, 0.3) !important;
+    box-shadow: 0 0 5px #8a2be2;
 }
 
-.glow-input label {
-    color: #a855f7;
-    text-transform: uppercase;
-    font-size: 0.8em;
-    letter-spacing: 1px;
+/* 2. The Image (CRITICAL FIX: 24px) */
+/* Targeted directly with high specificity */
+.discipline-drop-zone img {
+    display: block !important;
+    width: 24px !important;
+    height: 24px !important;
+    
+    flex: 0 0 24px !important; 
+    min-width: 24px !important; 
+    max-width: 24px !important;
+    
+    object-fit: cover !important;
+    border: none !important;
+    margin: 0 8px 0 0 !important; 
+    padding: 0 !important;
+    background: transparent !important;
 }
 
-/* --- D. OFFICE DOSSIER THEME (Species, Package) --- */
-.item.species-theme, .item.package-theme {
-    background: #f4e4bc; /* Manila Folder Beige */
-    color: #333;
-    font-family: "Courier Prime", "Courier New", monospace;
-    border: 1px solid #c7b28a;
-}
-
-.item.species-theme .sheet-header, .item.package-theme .sheet-header {
-    background: rgba(0,0,0,0.05);
-    border-bottom: 2px solid #555;
-}
-
-.item.species-theme input, .item.package-theme input {
-    background: transparent;
-    border: none;
-    border-bottom: 1px solid #555;
-    color: #000;
-    font-family: "Courier New", monospace;
+/* 3. The Text Name */
+.discipline-drop-zone .linked-name {
     font-weight: bold;
+    color: #d8bfff;
+    font-size: 1.1em;
+    white-space: nowrap; 
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-right: 8px !important;
+    line-height: 24px;
 }
 
-.office-dossier {
-    padding: 10px;
-}
-
-.dossier-stamp {
-    border: 2px solid #d00;
+/* 4. The Close 'X' Button */
+.discipline-drop-zone .remove-discipline {
     color: #d00;
-    display: inline-block;
-    padding: 2px 10px;
-    font-weight: bold;
-    transform: rotate(-2deg);
-    margin-bottom: 15px;
-    font-family: "Arial Black", sans-serif;
-    opacity: 0.7;
-}
-
-.paper-section {
-    margin-bottom: 15px;
-    border: 1px solid #ccc;
-    padding: 5px;
-    background: rgba(255,255,255,0.3);
-}
-
-.paper-header {
-    background: #333;
-    color: #fff;
-    padding: 2px 5px;
-    font-size: 0.8em;
-    text-transform: uppercase;
-    margin-bottom: 5px;
-}
-
-.paper-row {
+    font-size: 1.1em;
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    margin-bottom: 5px;
+    justify-content: center;
+    height: 24px;
+    width: 16px; 
 }
 
-/* Stat Grid for Species/Package */
-.stat-limits-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 5px;
+/* 5. Placeholder Text (When Empty) */
+.discipline-drop-zone:not(:has(img)) {
+    border: 2px dashed #666 !important; 
+    background: rgba(0,0,0,0.2) !important;
 }
 
-.limit-box {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: 1px dotted #999;
-    padding: 2px;
+.discipline-drop-zone .placeholder {
+    color: #888;
+    font-style: italic;
+    font-size: 0.9em;
 }
-.limit-box label { font-size: 0.8em; font-weight: bold; }
+
+
+/* ==========================================
+   REMAINING THEMES (Dossier & Global)
+   ========================================== */
+
+/* D. DOSSIER THEME (Species, Package) */
+.item.species .window-content, .item.package .window-content {
+    background: #f4e4bc !important; color: #333; font-family: "Courier Prime", monospace; border: 1px solid #c7b28a;
+}
+.item.species .sheet-header, .item.package .sheet-header { background: rgba(0,0,0,0.05) !important; border-bottom: 2px solid #555; color: #000 !important; }
+.item.species input, .item.package input { background: transparent !important; border: none !important; border-bottom: 1px solid #555 !important; color: #000 !important; font-weight: bold; }
+
+/* Dossier Layouts */
+.office-dossier { padding: 10px; }
+.dossier-stamp { border: 2px solid #d00; color: #d00; display: inline-block; padding: 2px 10px; font-weight: bold; transform: rotate(-2deg); margin-bottom: 15px; opacity: 0.7; }
+.paper-section { margin-bottom: 15px; border: 1px solid #ccc; padding: 5px; background: rgba(255,255,255,0.3); }
+.paper-header { background: #333; color: #fff; padding: 2px 5px; font-size: 0.8em; font-weight:bold; margin-bottom: 5px; }
+.stat-limits-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 5px; }
+.limit-box { display: flex; justify-content: space-between; align-items: center; border-bottom: 1px dotted #999; padding: 2px; }
 .limit-box input { width: 30px; text-align: center; }
 
-/* Skill Granting Area */
+/* Skill Granting Area (Only for Dossier now) */
 .skill-grant-area {
     min-height: 60px;
     border: 2px dashed #999;
     padding: 5px;
     background: rgba(0,0,0,0.02);
+    display: flex; flex-wrap: wrap; align-items: center; width: 100%;
+}
+.granted-skill-chip { 
+    display: inline-flex; align-items: center; background: #e0e0e0; border: 1px solid #999; 
+    padding: 2px 6px; margin: 2px; border-radius: 3px; font-size: 0.9em; 
+}
+.granted-skill-chip img { 
+    height: 24px !important; width: 24px !important; margin-right: 5px !important; border: 1px solid #555 !important; 
+    object-fit: cover !important;
+}
+.delete-grant { margin-left: 5px; color: #d00; cursor: pointer; }
+.empty-dossier-text { width: 100%; text-align: center; color: #777; font-style: italic; padding-top: 15px; }
+
+/* Global Image Fix (List Images - Strict 30px Box) */
+/* This catches the inventory tab lists */
+.sla-industries.sheet.actor .item .item-image,
+.sla-sheet .item .item-image {
+    flex: 0 0 30px !important;
+    width: 30px !important;
+    min-width: 30px !important;
+    max-width: 30px !important;
+    height: 30px !important;
+    
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    
+    margin-right: 5px !important;
+    padding: 0 !important;
+    overflow: hidden !important; 
 }
 
-.granted-skill-chip {
-    display: inline-flex;
-    align-items: center;
-    background: #e0e0e0;
-    border: 1px solid #999;
-    padding: 2px 6px;
-    margin: 2px;
-    border-radius: 3px;
-    font-size: 0.9em;
+.sla-industries.sheet.actor .item .item-image img,
+.sla-sheet .item .item-image img {
+    width: 24px !important;
+    height: 24px !important;
+    flex: 0 0 24px !important;
+    object-fit: cover !important; 
+    border: 1px solid #444 !important;
+    background: #000 !important;
+    margin: 0 !important;
+    display: block !important;
 }
 
-.delete-grant {
-    margin-left: 5px;
-    color: #d00;
-    cursor: pointer;
+/* Header Profile Image */
+.sla-industries.item .sheet-header .profile-img {
+    flex: 0 0 64px; width: 64px; height: 64px; object-fit: cover; border: 1px solid #000; margin-right: 10px; background: #000;      
 }
-.delete-grant:hover { color: #f00; }
-
-.empty-dossier-text {
-    width: 100%;
-    text-align: center;
-    color: #777;
-    font-style: italic;
-    padding-top: 15px;
-}
-
-/* --- E. ITEM SHEET IMAGE FIX --- */
-.sla-sheet.item .sheet-header .profile-img {
-    flex: 0 0 64px;          
-    width: 64px;           
-    height: 64px;         
-    object-fit: cover;     
-    border: 1px solid #000;
-    margin-right: 10px;    
-    background: #000;     
-}
-
-.sla-sheet.item .sheet-header {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-start;
-}
-
-.sla-sheet.item .header-details {
-    flex: 1;
-    overflow: hidden; 
-}
-
-/* ==========================================
-   17. SKILL LIST & TABLES
-   ========================================== */
-
-/* Header Row */
-.skill-group-header td,
-.sla-table thead th { /* Catch generic table headers too */
-    background: #111;
-    color: var(--sla-accent); 
-    font-family: var(--sla-font-header);
-    font-weight: 700;
-    text-transform: uppercase;
-    font-size: 0.85em;
-    padding: 4px 5px;
-    border-bottom: 1px solid var(--sla-border);
-    letter-spacing: 1px;
-}
-
-/* "Add Item" Icons in Headers */
-.sla-header-bar .item-create,
-.sla-table .item-create {
-    color: var(--sla-text-light);
-    cursor: pointer;
-    font-size: 0.9em;
-}
-.sla-header-bar .item-create:hover,
-.sla-table .item-create:hover {
-    color: var(--sla-accent);
-    text-shadow: 0 0 5px var(--sla-accent);
-}
-
-/* General Table Text */
-.sla-table td {
-    color: var(--sla-text-light) !important;
-    padding: 2px 5px;
-    border-bottom: 1px solid #222; /* Subtle separator between rows */
-}
-
-/* Icons (Edit/Delete) */
-.sla-table .item-controls a { color: #555; transition: color 0.2s; }
-.sla-table .item-controls a:hover { color: var(--sla-accent); }
-
-/* Item Image Styling */
-.sla-table .item-name img {
-    flex: 0 0 24px;         
-    width: 24px;           
-    height: 24px;         
-    object-fit: cover;     
-    border: 1px solid var(--sla-border);
-    background: #000;     
-    margin-right: 5px;
-}
-
-.sla-table .item-name {
-    display: flex;
-    align-items: center;
-    color: #fff !important;
-}
-
-/* Loadout Buttons */
-.sla-table .item-toggle i { color: #444; } /* Default dark */
-.sla-table .item-toggle i.fa-check-circle { color: #4CAF50 !important; } /* Active Green */
-
-/* ==========================================
-   Z. UNIVERSAL BACKGROUND OVERRIDE FIX
-   ========================================== */
-
-/* 1. Target the absolute root window content */
-.sla-sheet.window-content,
-.app.window-app .window-content {
-    background-image: none !important; 
-    background: var(--sla-bg-dark) !important;
-    background-color: var(--sla-bg-dark) !important;
-    box-shadow: none !important; 
-}
-
-/* 2. Target the form and internal structure */
-.sla-sheet form,
-.sla-sheet .sheet-body {
-    background: transparent !important; /* Let the root dark color show through */
-    background-image: none !important;
-}
-
-/* 3. Target all Tabs and inner containers */
-.sla-sheet .tab,
-.sla-sheet .tab .full-height,
-.sla-sheet .tab > .flexcol.full-height {
-    background-image: none !important;
-    background-color: transparent !important; /* Transparent so they match the root */
-}
-
-/* Inventory Header Styling */
-.sla-sheet .inventory-header {
-    background: rgba(0, 0, 0, 0.5); /* Dark background for header */
-    border: 1px solid var(--sla-accent); /* Green border */
-    color: var(--sla-accent);
-    font-weight: bold;
-    padding: 5px;
-    margin-bottom: 2px;
-}
-
-/* List Row Styling */
-.sla-sheet .inventory-list .item {
-    background: rgba(0, 0, 0, 0.2);
-    border-bottom: 1px solid #333;
-    padding: 4px;
-    align-items: center; /* Vertically center content */
-}
-
-.sla-sheet .inventory-list .item:hover {
-    background: rgba(57, 255, 20, 0.1); /* Slight green glow on hover */
-}
-
-/* Column Widths */
-.sla-sheet .item-image { flex: 0 0 30px; text-align: center; }
-.sla-sheet .item-name { flex: 2; margin: 0 5px; color: #eee; }
-.sla-sheet .item-detail { flex: 0 0 50px; text-align: center; color: #aaa; font-size: 0.9em; }
-.sla-sheet .item-controls { flex: 0 0 60px; text-align: right; }
-
-.sla-sheet .item-control { color: #888; margin-left: 5px; }
-.sla-sheet .item-control:hover { color: var(--sla-accent); text-shadow: 0 0 5px var(--sla-accent); }
-.sla-sheet .item-control.active { color: var(--sla-accent); } /* For equipped items */
+.sla-industries.item .sheet-header { display: flex; flex-direction: row; align-items: center; justify-content: flex-start; }
+.sla-industries.item .header-details { flex: 1; overflow: hidden; }

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -20,7 +20,11 @@ export const preloadHandlebarsTemplates = async function() {
 	"systems/sla-industries/templates/partials/header-card.hbs",
     "systems/sla-industries/templates/partials/main-tab.hbs",
 	"systems/sla-industries/templates/partials/inventory-tab.hbs",
-    "systems/sla-industries/templates/partials/bio-traits-tab.hbs"
+    "systems/sla-industries/templates/partials/bio-traits-tab.hbs",
+	"systems/sla-industries/templates/partials/item-catalogue.hbs",
+  "systems/sla-industries/templates/partials/item-academic.hbs",
+  "systems/sla-industries/templates/partials/item-spectral.hbs",
+  "systems/sla-industries/templates/partials/item-dossier.hbs"
   ];
 
   // Load the template parts

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -9,25 +9,32 @@ export class SlaItemSheet extends ItemSheet {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["sla-industries", "sheet", "item"],
       template: "systems/sla-industries/templates/item/item-sheet.hbs",
-      width: 520,
-      height: 480,
+      width: 550,
+      height: 600, // INCREASED from 480 to 600
       tabs: [{ navSelector: ".sheet-tabs", contentSelector: ".sheet-body", initial: "attributes", group: "primary" }]
     });
   }
 
-  // module/sheets/item-sheet.mjs
+  // --------------------------------------------
+  //  DATA PREPARATION
+  // --------------------------------------------
 
+	/** @override */
   async getData() {
-    const context = await super.getData(); // Ensure we await super
+    const context = await super.getData();
     const itemData = context.item;
     context.system = itemData.system;
     context.flags = itemData.flags;
     context.config = CONFIG.SLA; 
 
-    // --- NEW: EBB IMAGE LOOKUP ---
-    // This finds the icon for the partial to display
+    // --- 1. ENRICH DESCRIPTION (The Missing Part) ---
+    context.enrichedDescription = await TextEditor.enrichHTML(this.item.system.description, {
+      async: true,
+      relativeTo: this.item
+    });
+
+    // --- 2. EBB IMAGE LOOKUP ---
     if (this.item.actor && context.system.discipline) {
-        // Find an item on the actor with the SAME NAME and type 'discipline'
         const disciplineItem = this.item.actor.items.find(i => 
             i.type === "discipline" && 
             i.name.toLowerCase() === context.system.discipline.toLowerCase()
@@ -40,12 +47,16 @@ export class SlaItemSheet extends ItemSheet {
     return context;
   }
 
+  // --------------------------------------------
+  //  EVENT LISTENERS
+  // --------------------------------------------
+
   /** @override */
   activateListeners(html) {
     super.activateListeners(html);
     if (!this.isEditable) return;
 
-    // --- 1. MAGAZINE LINKING (Existing) ---
+    // --- 1. MAGAZINE LINKING (Weapons) ---
     const weaponDropZone = html.find('.weapon-link');
     if (weaponDropZone.length > 0) {
         weaponDropZone[0].addEventListener('drop', this._onDropWeapon.bind(this));
@@ -57,30 +68,57 @@ export class SlaItemSheet extends ItemSheet {
         await this.item.update({ "system.linkedWeapon": "" });
     });
 
-    // --- 2. EBB DISCIPLINE LINKING (NEW) ---
+    // --- 2. WEAPON SKILL LINKING (NEW) ---
+    const weaponSkillZone = html.find('.skill-link');
+    if (weaponSkillZone.length > 0) {
+        // Use jQuery .on to catch originalEvent easily
+        weaponSkillZone.on("dragover", event => event.preventDefault());
+        weaponSkillZone.on("drop", this._onDropWeaponSkill.bind(this));
+    }
+
+    html.find('.remove-skill-link').click(async ev => {
+        ev.preventDefault();
+        await this.item.update({ "system.skill": "" });
+    });
+
+    // --- 3. EBB DISCIPLINE LINKING ---
+    const disciplineDropZone = html.find('.discipline-drop-zone');
     
-    // A. Delete Handler
-    // We use .on() attached to the container to ensure it catches clicks even if re-rendered
+    // A. Drop Handler
+    if (disciplineDropZone.length > 0) {
+        disciplineDropZone[0].addEventListener('drop', this._onDropDiscipline.bind(this));
+        disciplineDropZone[0].addEventListener('dragover', (ev) => {
+             ev.preventDefault(); 
+             ev.dataTransfer.dropEffect = 'copy';
+        });
+    }
+
+    // B. Delete Handler (Delegated)
     html.find('.discipline-drop-zone').on('click', '.remove-discipline', async (ev) => {
         ev.preventDefault();
         ev.stopPropagation();
         await this.item.update({ "system.discipline": "" });
     });
 
-    // B. Drop Handler
-    const disciplineDropZone = html.find('.discipline-drop-zone');
-    if (disciplineDropZone.length > 0) {
-        disciplineDropZone[0].addEventListener('drop', this._onDropDiscipline.bind(this));
-        // Add dragover to ensure the browser allows the drop
-        disciplineDropZone[0].addEventListener('dragover', (ev) => {
-             ev.preventDefault(); 
-             ev.dataTransfer.dropEffect = 'copy';
-        });
+    // --- 4. SKILL GRANTING (Species & Packages) ---
+    const skillDropZone = html.find('.skill-grant-area');
+
+    // A. Drop Handler (Using jQuery .on to access originalEvent)
+    if (skillDropZone.length > 0) {
+        skillDropZone.on("dragover", event => event.preventDefault());
+        skillDropZone.on("drop", this._onDropSkill.bind(this));
     }
+
+    // B. Delete Handler (Delegated)
+    html.find('.skill-grant-area').on("click", ".delete-grant", this._onDeleteSkill.bind(this));
   }
 
+  // --------------------------------------------
+  //  DROP HANDLERS
+  // --------------------------------------------
+
   /**
-   * Handle dropping a weapon item to link it to this magazine
+   * Handle dropping a Weapon item to link it to this Magazine
    */
   async _onDropWeapon(event) {
       event.preventDefault();
@@ -101,7 +139,33 @@ export class SlaItemSheet extends ItemSheet {
   }
 
   /**
-   * --- NEW: Handle dropping a Discipline item ---
+   * Handle dropping a Skill item onto a Weapon to set requirement
+   */
+  async _onDropWeaponSkill(event) {
+    event.preventDefault();
+    try {
+        const data = JSON.parse(event.originalEvent.dataTransfer.getData('text/plain'));
+        if (data.type !== "Item") return;
+
+        const item = await Item.implementation.fromDropData(data);
+        
+        // Validation: Must be a Skill
+        if (!item || item.type !== "skill") {
+            return ui.notifications.warn("Only 'Skill' items can be linked to a weapon.");
+        }
+
+        // Save the NAME of the skill (e.g., "Pistol", "Melee")
+        await this.item.update({
+            "system.skill": item.name
+        });
+        
+    } catch (err) {
+        console.error("SLA | Weapon Skill Drop Failed:", err);
+    }
+  }
+
+  /**
+   * Handle dropping a Discipline item onto an Ebb Formula
    */
   async _onDropDiscipline(event) {
     event.preventDefault();
@@ -113,12 +177,10 @@ export class SlaItemSheet extends ItemSheet {
 
         const item = await Item.implementation.fromDropData(data);
         
-        // Validation: Must be a Discipline
         if (!item || item.type !== "discipline") {
             return ui.notifications.warn("Only 'Discipline' items can be linked here.");
         }
 
-        // Update the Formula with the name of the dropped discipline
         await this.item.update({
             "system.discipline": item.name
         });
@@ -126,5 +188,65 @@ export class SlaItemSheet extends ItemSheet {
     } catch (err) {
         console.error("SLA | Discipline Drop Failed:", err);
     }
+  }
+
+  /**
+   * Handle dropping a Skill onto Species/Package (Creates List)
+   */
+  async _onDropSkill(event) {
+    event.preventDefault();
+    try {
+        // jQuery wraps the event, so we need originalEvent for dataTransfer
+        const data = JSON.parse(event.originalEvent.dataTransfer.getData('text/plain'));
+        if (data.type !== "Item") return;
+
+        const item = await Item.implementation.fromDropData(data);
+        
+        // Validation
+        if (!item || item.type !== "skill") {
+            return ui.notifications.warn("Only Skills can be added to this list.");
+        }
+
+        // 1. Get the current list (safely)
+        let currentSkills = this.item.system.skills;
+        if (!Array.isArray(currentSkills)) {
+            currentSkills = [];
+        }
+
+        // 2. Build the data object
+        const newSkill = {
+            name: item.name,
+            rank: item.system.rank || 1,
+            img: item.img || "icons/svg/item-bag.svg"
+        };
+
+        // 3. Check for duplicates
+        if (currentSkills.some(s => s.name === newSkill.name)) {
+            return ui.notifications.warn(`${newSkill.name} is already in the list.`);
+        }
+
+        // 4. Update the Item
+        const newArray = [...currentSkills, newSkill];
+        await this.item.update({ "system.skills": newArray });
+
+    } catch (err) {
+        console.error("SLA | Skill Drop Failed:", err);
+    }
+  }
+
+  /**
+   * Handle deleting a skill from the Species/Package list
+   */
+  async _onDeleteSkill(event) {
+    event.preventDefault();
+    const target = event.currentTarget;
+    const index = Number(target.dataset.index);
+
+    const currentSkills = this.item.system.skills || [];
+    
+    // Filter out the specific index
+    const newArray = currentSkills.filter((_, i) => i !== index);
+
+    await this.item.update({ "system.skills": newArray });
   }
 }

--- a/module/sla-industries.mjs
+++ b/module/sla-industries.mjs
@@ -58,6 +58,17 @@ Hooks.once('init', async function() {
     "species": "Species",
     "package": "Training Package"
   };
+  
+  // REGISTER HANDLEBARS HELPERS
+  Handlebars.registerHelper('capitalize', function(str) {
+    if (typeof str !== 'string') return '';
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  });
+
+  Handlebars.registerHelper('upper', function(str) {
+    if (typeof str !== 'string') return '';
+    return str.toUpperCase();
+  });
 
   Actors.unregisterSheet("core", ActorSheet);
   Actors.registerSheet("sla-industries", SlaActorSheet, { types: ["character", "npc"], makeDefault: true, label: "SLA Operative Sheet" });

--- a/templates/item/item-sheet.hbs
+++ b/templates/item/item-sheet.hbs
@@ -6,7 +6,8 @@
         <div class="header-details">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Item Name"/></h1>
             <div class="item-subtitle">
-                <span class="type-label">{{item.type}}</span>
+                {{!-- FIX: Removed 'capitalize' and changed prefix to match en.json --}}
+                <span class="type-label">{{localize (concat "TYPES.Item." item.type)}}</span>
             </div>
         </div>
     </header>
@@ -23,192 +24,24 @@
         {{!-- ATTRIBUTES TAB --}}
         <div class="tab attributes" data-group="primary" data-tab="attributes">
             
-            {{!-- 1. CATALOGUE THEME (Weapons, Items, Armor, Drugs, Magazines) --}}
+            {{!-- 1. CATALOGUE THEME (Weapons, Armor, Gear, Drugs, Ammo) --}}
             {{#if (or (eq item.type "weapon") (or (eq item.type "item") (or (eq item.type "armor") (or (eq item.type "drug") (eq item.type "magazine")))))}}
-            <div class="catalogue-grid">
-                
-                {{!-- Common Fields --}}
-                <div class="form-group"><label>Weight</label><input type="number" name="system.weight" value="{{system.weight}}" step="0.1"/></div>
-                <div class="form-group"><label>Cost</label><input type="number" name="system.price" value="{{system.price}}"/></div>
-                <div class="form-group"><label>Quantity</label><input type="number" name="system.quantity" value="{{system.quantity}}" placeholder="1"/></div>
-                
-                {{!-- WEAPON Specific --}}
-                {{#if (eq item.type "weapon")}}
-                <div class="form-group"><label>Damage</label><input type="text" name="system.damage" value="{{system.damage}}"/></div>
-                <div class="form-group"><label>Min Dmg</label><input type="text" name="system.minDamage" value="{{system.minDamage}}"/></div>
-                
-                <div class="form-group"><label>AD (Armor Dmg)</label><input type="number" name="system.ad" value="{{system.ad}}"/></div>
-                <div class="form-group"><label>Recoil</label><input type="text" name="system.recoil" value="{{system.recoil}}"/></div>
-                
-                <div class="form-group"><label>ROF</label><input type="text" name="system.rof" value="{{system.rof}}"/></div>
-                <div class="form-group"><label>Range</label><input type="text" name="system.range" value="{{system.range}}"/></div>
-                
-                <div class="form-group" style="grid-column: 1 / -1;">
-                    <label>Skill</label>
-                    <select name="system.skill" style="width: 100%;">{{selectOptions @root.config.combatSkills selected=system.skill}}</select>
-                </div>
-                {{/if}}
-
-                {{!-- MAGAZINE Specific --}}
-                {{#if (eq item.type "magazine")}}
-                <div class="form-group" style="grid-column: 1 / -1; margin-top: 10px; border-top: 2px dashed #555; padding-top: 5px;">
-                    <label style="width:100%; text-align:center; color:#333;">MAGAZINE PROPERTIES</label>
-                </div>
-
-                <div class="form-group">
-                    <label>Rounds in Clip</label>
-                    <input type="number" name="system.ammoCapacity" value="{{system.ammoCapacity}}" placeholder="30"/>
-                </div>
-                
-                <div class="form-group">
-                    <label>Ammunition Type</label>
-                    <div class="form-fields">
-                        <select name="system.ammoType">
-                            {{selectOptions @root.config.ammoTypes selected=system.ammoType localize=false}}
-                        </select>
-                    </div>
-                </div>
-
-                <div class="form-group" style="grid-column: 1 / -1; margin-top:10px;">
-                    <label style="margin-bottom:5px;">Linked Weapon:</label>
-                    <div class="drop-zone weapon-link" style="height: 50px; border: 2px dashed #999; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.05);">
-                        {{#if system.linkedWeapon}}
-                            <span style="font-weight:bold; color:#222; font-size:1.2em;">{{system.linkedWeapon}}</span>
-                            <a class="remove-link" title="Unlink" style="margin-left:10px; color:#d00; cursor:pointer;"><i class="fas fa-times"></i></a>
-                        {{else}}
-                            <span style="font-style:italic; color:#777;">Drop Weapon Item Here to Link</span>
-                        {{/if}}
-                    </div>
-                </div>
-                {{/if}}
-
-                {{!-- STANDARD ITEM (Generic) --}}
-                {{#if (eq item.type "item")}}
-                {{!-- No extra fields --}}
-                {{/if}}
-
-                {{!-- ARMOR Specific --}}
-                {{#if (eq item.type "armor")}}
-                <div class="form-group"><label>PV (Prot)</label><input type="number" name="system.pv" value="{{system.pv}}"/></div>
-                <div class="form-group"><label>Resist (Cur / Max)</label>
-                    <div class="flexrow"><input type="number" name="system.resistance.value" value="{{system.resistance.value}}"/> / <input type="number" name="system.resistance.max" value="{{system.resistance.max}}"/></div>
-                </div>
-                {{/if}}
-
-                {{!-- DRUG Specific --}}
-                {{#if (eq item.type "drug")}}
-                <div class="form-group"><label>Duration</label><input type="number" name="system.duration" value="{{system.duration}}"/></div>
-                <div class="form-group"><label>Addiction</label><input type="number" name="system.addiction" value="{{system.addiction}}"/></div>
-                <div class="form-group" style="grid-column: 1 / -1;"><label style="text-align:center; width:100%;">STAT MODIFIERS</label></div>
-                
-                <div class="form-group">
-                    <label>Mod 1</label>
-                    <select name="system.mods.first.stat"><option value="">- None -</option>{{selectOptions @root.config.stats selected=system.mods.first.stat}}</select>
-                </div>
-                <div class="form-group"><label>Val</label><input type="number" name="system.mods.first.value" value="{{system.mods.first.value}}"/></div>
-                
-                <div class="form-group">
-                    <label>Mod 2</label>
-                    <select name="system.mods.second.stat"><option value="">- None -</option>{{selectOptions @root.config.stats selected=system.mods.second.stat}}</select>
-                </div>
-                <div class="form-group"><label>Val</label><input type="number" name="system.mods.second.value" value="{{system.mods.second.value}}"/></div>
-                {{/if}}
-
-            </div>
+                {{> "systems/sla-industries/templates/partials/item-catalogue.hbs"}}
             {{/if}}
 
             {{!-- 2. ACADEMIC THEME (Skills, Traits) --}}
             {{#if (or (eq item.type "skill") (eq item.type "trait"))}}
-            <div class="academic-paper">
-                <div class="form-group line-item"><label>Current Rank:</label><input type="number" name="system.rank" value="{{system.rank}}" placeholder="0"/></div>
-                {{#if (eq item.type "skill")}}
-                <div class="form-group line-item">
-                    <label>Related Stat:</label>
-                    <select name="system.stat">{{selectOptions @root.config.stats selected=system.stat}}</select>
-                </div>
-                {{/if}}
-                {{#if (eq item.type "trait")}}
-                <div class="form-group line-item"><label>Type:</label><input type="text" name="system.type" value="{{system.type}}" placeholder="Advantage / Disadvantage"/></div>
-                {{/if}}
-                <div class="form-group line-item"><label>XP Cost:</label><input type="number" name="system.xpCost" value="{{system.xpCost}}"/></div>
-            </div>
+                {{> "systems/sla-industries/templates/partials/item-academic.hbs"}}
             {{/if}}
 
-            {{!-- 3. SPECTRAL THEME (Ebb & Disciplines) --}}
+            {{!-- 3. SPECTRAL THEME (Ebb, Discipline) --}}
             {{#if (or (eq item.type "ebbFormula") (eq item.type "discipline"))}}
-            <div class="spectral-container">
-                
-                {{!-- Common Flux Cost --}}
-                <div class="form-group glow-input">
-                    <label>Flux Cost</label>
-                    <input type="number" name="system.cost" value="{{system.cost}}"/>
-                </div>
-
-                {{!-- DISCIPLINE ITEM SPECIFIC --}}
-                {{#if (eq item.type "discipline")}}
-                    <div class="form-group glow-input">
-                        <label>Rank</label>
-                        <input type="number" name="system.rank" value="{{system.rank}}"/>
-                    </div>
-                {{/if}}
-
-                {{!-- EBB FORMULA ITEM SPECIFIC --}}
-                {{#if (eq item.type "ebbFormula")}}
-                    <div class="form-group glow-input">
-                        <label>FR</label>
-                        <input type="number" name="system.formulaRating" value="{{system.formulaRating}}"/>
-                    </div>
-
-                    {{!-- PARTIAL: Discipline Drop Zone --}}
-                    {{> "systems/sla-industries/templates/partials/ebb-drop-zone.hbs"}}
-
-                    {{!-- Combat Stats Grid --}}
-                    <div class="catalogue-grid" style="background:transparent; border:none; padding:0; margin-top:10px;">
-                        <div class="form-group glow-input"><label>Dmg</label><input type="text" name="system.damage" value="{{system.damage}}"/></div>
-                        <div class="form-group glow-input"><label>Min</label><input type="text" name="system.minDamage" value="{{system.minDamage}}"/></div>
-                        <div class="form-group glow-input"><label>AD</label><input type="number" name="system.ad" value="{{system.ad}}"/></div>
-                        <div class="form-group glow-input"><label>ROF</label><input type="text" name="system.rof" value="{{system.rof}}"/></div>
-                        <div class="form-group glow-input"><label>Rec</label><input type="text" name="system.recoil" value="{{system.recoil}}"/></div>
-                        <div class="form-group glow-input"><label>Rng</label><input type="text" name="system.range" value="{{system.range}}"/></div>
-                    </div>
-                {{/if}}
-            </div>
+                {{> "systems/sla-industries/templates/partials/item-spectral.hbs"}}
             {{/if}}
 
             {{!-- 4. DOSSIER THEME (Species, Package) --}}
             {{#if (or (eq item.type "species") (eq item.type "package"))}}
-            <div class="office-dossier">
-                <div class="dossier-stamp">CONFIDENTIAL</div>
-                {{#if (eq item.type "species")}}
-                <div class="paper-section">
-                    <div class="paper-header">BIO</div>
-                    <div class="form-group paper-row"><label>HP</label><input type="number" name="system.hp" value="{{system.hp}}"/></div>
-                    <div class="form-group paper-row"><label>Move</label><div class="flexrow"><input type="number" name="system.move.closing" value="{{system.move.closing}}"/> / <input type="number" name="system.move.rushing" value="{{system.move.rushing}}"/></div></div>
-                    <div class="stat-limits-grid">
-                        <div class="limit-box"><label>STR</label><div class="flexrow"><input type="number" name="system.stats.str.min" value="{{system.stats.str.min}}"/>-<input type="number" name="system.stats.str.max" value="{{system.stats.str.max}}"/></div></div>
-                        <div class="limit-box"><label>DEX</label><div class="flexrow"><input type="number" name="system.stats.dex.min" value="{{system.stats.dex.min}}"/>-<input type="number" name="system.stats.dex.max" value="{{system.stats.dex.max}}"/></div></div>
-                        <div class="limit-box"><label>KNOW</label><div class="flexrow"><input type="number" name="system.stats.know.min" value="{{system.stats.know.min}}"/>-<input type="number" name="system.stats.know.max" value="{{system.stats.know.max}}"/></div></div>
-                        <div class="limit-box"><label>CONC</label><div class="flexrow"><input type="number" name="system.stats.conc.min" value="{{system.stats.conc.min}}"/>-<input type="number" name="system.stats.conc.max" value="{{system.stats.conc.max}}"/></div></div>
-                        <div class="limit-box"><label>CHA</label><div class="flexrow"><input type="number" name="system.stats.cha.min" value="{{system.stats.cha.min}}"/>-<input type="number" name="system.stats.cha.max" value="{{system.stats.cha.max}}"/></div></div>
-                        <div class="limit-box"><label>COOL</label><div class="flexrow"><input type="number" name="system.stats.cool.min" value="{{system.stats.cool.min}}"/>-<input type="number" name="system.stats.cool.max" value="{{system.stats.cool.max}}"/></div></div>
-                    </div>
-                </div>
-                {{/if}}
-                {{#if (eq item.type "package")}}
-                <div class="paper-section">
-                    <div class="paper-header">PREREQUISITES</div>
-                    <div class="stat-limits-grid">
-                        <div class="limit-box"><label>STR</label><input type="number" name="system.requirements.str" value="{{system.requirements.str}}"/></div>
-                        <div class="limit-box"><label>DEX</label><input type="number" name="system.requirements.dex" value="{{system.requirements.dex}}"/></div>
-                        <div class="limit-box"><label>KNOW</label><input type="number" name="system.requirements.know" value="{{system.requirements.know}}"/></div>
-                        <div class="limit-box"><label>CONC</label><input type="number" name="system.requirements.conc" value="{{system.requirements.conc}}"/></div>
-                        <div class="limit-box"><label>CHA</label><input type="number" name="system.requirements.cha" value="{{system.requirements.cha}}"/></div>
-                        <div class="limit-box"><label>COOL</label><input type="number" name="system.requirements.cool" value="{{system.requirements.cool}}"/></div>
-                    </div>
-                </div>
-                {{/if}}
-                <div class="paper-section"><div class="paper-header">GRANTED SKILLS</div><div class="drop-zone skill-grant-area">{{#each system.skills as |skill index|}}<div class="granted-skill-chip"><span class="skill-name">{{skill.name}}</span><a class="delete-grant" data-index="{{index}}"><i class="fas fa-times"></i></a></div>{{else}}<div class="empty-dossier-text">Drop Skills Here</div>{{/each}}</div></div>
-            </div>
+                {{> "systems/sla-industries/templates/partials/item-dossier.hbs"}}
             {{/if}}
 
         </div>

--- a/templates/partials/bio-gear-tab.hbs
+++ b/templates/partials/bio-gear-tab.hbs
@@ -1,0 +1,44 @@
+<div class="flexcol full-height">
+    {{!-- Traits --}}
+    <div class="sla-panel" style="flex: 0 0 200px; margin-bottom: 5px;">
+        <div class="sla-header-bar flexrow">
+            <span style="flex:1">TRAITS</span>
+            <a class="item-create" data-type="trait" title="Add Trait"><i class="fas fa-plus"></i></a>
+        </div>
+        <div class="scroll-list">
+            <table class="sla-table">
+                <thead>
+                    <tr>
+                        <th style="text-align: left; padding-left: 5px;">Name</th>
+                        <th style="width: 50px;">Rank</th>
+                        <th style="width: 120px;">Type</th>
+                        <th style="width: 50px;">Cost</th>
+                        <th style="width: 50px;"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{#each traits as |trait|}}
+                    <tr class="item" data-item-id="{{trait._id}}">
+                        <td class="item-name rollable" data-roll-type="item" style="font-weight: bold; color: #fff; padding-left: 5px;">{{trait.name}}</td>
+                        <td style="text-align: center;">{{trait.system.rank}}</td>
+                        <td style="text-align: center;">{{trait.system.type}}</td>
+                        <td style="text-align: center;">{{trait.system.xpCost}}</td>
+                        <td class="item-controls">
+                            <a class="item-edit"><i class="fas fa-edit"></i></a>
+                            <a class="item-delete"><i class="fas fa-trash"></i></a>
+                        </td>
+                    </tr>
+                    {{/each}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    {{!-- Notes (Updated with Title Bar) --}}
+    <div class="sla-panel" style="flex: 1; min-height: 300px; display: flex; flex-direction: column;">
+        <div class="sla-header-bar">NOTES</div>
+        <div class="editor-container" style="flex: 1; border: none; padding: 5px; background: #000;">
+            {{editor enrichedBiography target="system.biography" button=true owner=owner editable=editable}}
+        </div>
+    </div>
+</div>

--- a/templates/partials/header-card.hbs
+++ b/templates/partials/header-card.hbs
@@ -1,88 +1,84 @@
 <header class="sheet-header">
     <div class="header-grid">
         
-        {{!-- 1. LEFT: SLA OPERATIVE CARD --}}
+        {{!-- LEFT: BIO & TRAITS --}}
         <div class="header-left">
-            <div class="header-section-title">SLA OPERATIVE SECURITY CLEARANCE CARD</div>
+            <h1 class="charname">
+                <input name="name" type="text" value="{{actor.name}}" placeholder="Operative Name"/>
+            </h1>
             
+            {{!-- Sub-Header Details --}}
             <div class="header-fields">
+                <div class="form-group">
+                    <label class="label-bold">Species</label>
+                    <div class="chip">
+                        {{#if speciesItem}}
+                            <img src="{{speciesItem.img}}"/>
+                            <span class="chip-name">{{speciesItem.name}}</span>
+                            <a class="chip-delete" data-type="species"><i class="fas fa-times"></i></a>
+                        {{else}}
+                            <div class="chip-placeholder">Drop Species Here</div>
+                        {{/if}}
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label class="label-bold">Package</label>
+                    <div class="chip">
+                        {{#if packageItem}}
+                            <img src="{{packageItem.img}}"/>
+                            <span class="chip-name">{{packageItem.name}}</span>
+                            <a class="chip-delete" data-type="package"><i class="fas fa-times"></i></a>
+                        {{else}}
+                            <div class="chip-placeholder">Drop Training Package</div>
+                        {{/if}}
+                    </div>
+                </div>
+            </div>
+
+            {{!-- Bottom Bar (LAD Checkbox Restored) --}}
+            <div class="header-bottom-bar">
+                <div class="lad-wrapper" style="display:flex; align-items:center;">
+                    <label style="margin-right: 5px; cursor:pointer;" for="lad-check">LAD</label>
+                    <input type="checkbox" id="lad-check" name="system.bio.lad" {{checked system.bio.lad}} 
+                           style="height:16px; width:16px; margin:0; cursor:pointer; accent-color:#D05E1A;"/>
+                </div>
                 
-                {{!-- ROW 1: NAME --}}
-                <div class="form-group">
-                    <label class="label-bold">NAME:</label>
-                    <input name="name" type="text" value="{{actor.name}}" placeholder="Operative Name"/>
-                </div>
-
-                {{!-- ROW 2: SQUAD --}}
-                <div class="form-group">
-                    <label class="label-bold">SQUAD:</label>
-                    <input name="system.bio.squad" type="text" value="{{system.bio.squad}}"/>
-                </div>
-
-                {{!-- ROW 3: SPECIES --}}
-                <div class="form-group chip-row">
-                    <label class="label-bold">SPECIES:</label>
-                    {{#if speciesItem}}
-                    <div class="chip" data-item-id="{{speciesItem._id}}">
-                        <img src="{{speciesItem.img}}"/>
-                        <span class="chip-name">{{speciesItem.name}}</span>
-                        <a class="chip-delete" data-type="species"><i class="fas fa-times"></i></a>
-                    </div>
-                    {{else}}
-                    <div class="chip-placeholder">Drag Species</div>
-                    {{/if}}
-                </div>
-
-                {{!-- ROW 4: PACKAGE --}}
-                <div class="form-group chip-row">
-                    <label class="label-bold">PACKAGE:</label>
-                    {{#if packageItem}}
-                    <div class="chip" data-item-id="{{packageItem._id}}">
-                        <img src="{{packageItem.img}}"/>
-                        <span class="chip-name">{{packageItem.name}}</span>
-                        <a class="chip-delete" data-type="package"><i class="fas fa-times"></i></a>
-                    </div>
-                    {{else}}
-                    <div class="chip-placeholder">Drag Package</div>
-                    {{/if}}
-                </div>
-
-                {{!-- ROW 5: LAD & SCL (Side by Side) --}}
-                <div class="header-bottom-bar">
-                    <div class="lad-wrapper">
-                        <input type="checkbox" name="system.bio.ladAccount" id="ladCheck" {{checked system.bio.ladAccount}}/>
-                        <label for="ladCheck">LAD ACCOUNT</label>
-                    </div>
-                    <div class="scl-wrapper">
-                        <label>SCL</label>
-                        <input type="text" name="system.bio.scl" value="{{system.bio.scl}}" data-dtype="Number"/>
-                    </div>
+                <div class="scl-wrapper">
+                    SCL: <input type="text" name="system.bio.scl" value="{{system.bio.scl}}" data-dtype="String"/>
                 </div>
             </div>
         </div>
 
-        {{!-- 2. CENTER: PORTRAIT --}}
+        {{!-- CENTER: PORTRAIT --}}
         <div class="portrait-container">
             <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}"/>
         </div>
 
-        {{!-- 3. RIGHT: FINANCE --}}
-        <div class="finance-box sla-panel">
-            <div class="finance-header">SLA INDUSTRIES</div>
-            <div class="finance-title">Finance</div>
-            <div class="finance-body">
-                <div class="fin-row">
-                    <label>CREDITS:</label>
-                    <input type="number" name="system.finance.credits" value="{{system.finance.credits}}"/>
+        {{!-- RIGHT: FINANCE --}}
+        <div class="finance-box">
+            <div class="finance-header" style="text-align:center; padding-top:5px; border-bottom:1px solid #444;">FINANCE</div>
+            
+            <div class="sla-pad" style="flex:1; display:flex; flex-direction:column; justify-content:space-evenly;">
+                
+                {{!-- Credits --}}
+                <div style="margin-bottom:5px;">
+                    <label style="font-size:0.8em; font-weight:bold; color:#aaa; display:block; margin-bottom:2px;">CREDITS</label>
+                    <input type="number" name="system.finance.credits" value="{{system.finance.credits}}" style="width:100%; text-align:right; color:#39ff14; font-weight:bold;"/>
                 </div>
-                <div class="fin-row">
-                    <label>UNIS:</label>
-                    <input type="number" name="system.finance.unis" value="{{system.finance.unis}}"/>
+
+                {{!-- UNIS --}}
+                <div style="margin-bottom:5px;">
+                    <label style="font-size:0.8em; font-weight:bold; color:#aaa; display:block; margin-bottom:2px;">UNIS</label>
+                    <input type="number" name="system.finance.unis" value="{{system.finance.unis}}" style="width:100%; text-align:right;"/>
                 </div>
-                <div class="fin-row">
-                    <label>LAD BAL:</label>
-                    <input type="text" name="system.finance.lad" value="{{system.finance.lad}}"/>
+
+                {{!-- Debt --}}
+                <div>
+                    <label style="font-size:0.8em; font-weight:bold; color:#d00; display:block; margin-bottom:2px;">DEBT</label>
+                    <input type="number" name="system.finance.debt" value="{{system.finance.debt}}" style="width:100%; text-align:right; color:#ff5555;"/>
                 </div>
+
             </div>
         </div>
 

--- a/templates/partials/item-academic.hbs
+++ b/templates/partials/item-academic.hbs
@@ -1,0 +1,13 @@
+<div class="academic-paper">
+    <div class="form-group line-item"><label>Rank:</label><input type="number" name="system.rank" value="{{system.rank}}"/></div>
+    {{#if (eq item.type "skill")}}
+    <div class="form-group line-item">
+        <label>Stat:</label>
+        <select name="system.stat">{{selectOptions @root.config.stats selected=system.stat}}</select>
+    </div>
+    {{/if}}
+    {{#if (eq item.type "trait")}}
+    <div class="form-group line-item"><label>Type:</label><input type="text" name="system.type" value="{{system.type}}"/></div>
+    {{/if}}
+    <div class="form-group line-item"><label>XP Cost:</label><input type="number" name="system.xpCost" value="{{system.xpCost}}"/></div>
+</div>

--- a/templates/partials/item-catalogue.hbs
+++ b/templates/partials/item-catalogue.hbs
@@ -1,0 +1,80 @@
+<div class="catalogue-grid">
+    {{!-- Common Fields --}}
+    <div class="form-group"><label>Weight</label><input type="number" name="system.weight" value="{{system.weight}}" step="0.1"/></div>
+    <div class="form-group"><label>Cost</label><input type="number" name="system.price" value="{{system.price}}"/></div>
+    <div class="form-group"><label>Qty</label><input type="number" name="system.quantity" value="{{system.quantity}}"/></div>
+
+    {{!-- WEAPON --}}
+    {{#if (eq item.type "weapon")}}
+        <div class="form-group"><label>Dmg</label><input type="text" name="system.damage" value="{{system.damage}}"/></div>
+        <div class="form-group"><label>Min</label><input type="text" name="system.minDamage" value="{{system.minDamage}}"/></div>
+        <div class="form-group"><label>AD</label><input type="number" name="system.ad" value="{{system.ad}}"/></div>
+        <div class="form-group"><label>Recoil</label><input type="text" name="system.recoil" value="{{system.recoil}}"/></div>
+        <div class="form-group"><label>ROF</label><input type="text" name="system.rof" value="{{system.rof}}"/></div>
+        <div class="form-group"><label>Range</label><input type="text" name="system.range" value="{{system.range}}"/></div>
+        
+        {{!-- Skill Drop Zone --}}
+        <div class="form-group" style="grid-column: 1 / -1;">
+            <label>Required Skill</label>
+            <div class="drop-zone skill-link" style="border: 2px dashed #999; padding: 5px; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.05); cursor: pointer; min-height: 30px;">
+                {{#if system.skill}}
+                    <span style="font-weight:bold; color:#222; font-size:1.1em; margin-right: 10px;">{{system.skill}}</span>
+                    <a class="remove-skill-link" title="Unlink Skill" style="color:#d00;"><i class="fas fa-times"></i></a>
+                {{else}}
+                    <span style="font-style:italic; color:#777;">Drop Skill Item Here</span>
+                {{/if}}
+            </div>
+        </div>
+    {{/if}}
+
+    {{!-- ARMOR --}}
+    {{#if (eq item.type "armor")}}
+        <div class="form-group"><label>PV</label><input type="number" name="system.pv" value="{{system.pv}}"/></div>
+        <div class="form-group"><label>Resist</label>
+            <div class="flexrow"><input type="number" name="system.resistance.value" value="{{system.resistance.value}}"/> / <input type="number" name="system.resistance.max" value="{{system.resistance.max}}"/></div>
+        </div>
+    {{/if}}
+    
+    {{!-- MAGAZINE --}}
+    {{#if (eq item.type "magazine")}}
+        <div class="form-group" style="grid-column: 1 / -1;"><label>Capacity</label><input type="number" name="system.ammoCapacity" value="{{system.ammoCapacity}}"/></div>
+        <div class="form-group" style="grid-column: 1 / -1;">
+             <label>Linked:</label>
+             <div class="drop-zone weapon-link" style="border:1px dashed #555; padding:5px;">
+                 {{#if system.linkedWeapon}}<b>{{system.linkedWeapon}}</b> <a class="remove-link"><i class="fas fa-times"></i></a>{{else}}Drop Weapon Here{{/if}}
+             </div>
+        </div>
+    {{/if}}
+
+    {{!-- DRUG (The Missing Section) --}}
+    {{#if (eq item.type "drug")}}
+        <div class="form-group"><label>Duration</label><input type="number" name="system.duration" value="{{system.duration}}"/></div>
+        <div class="form-group"><label>Addiction</label><input type="number" name="system.addiction" value="{{system.addiction}}"/></div>
+        
+        {{!-- Section Header --}}
+        <div class="form-group" style="grid-column: 1 / -1; margin-top: 10px; border-top: 2px solid #555; padding-top: 5px;">
+            <label style="width:100%; text-align:center;">STAT MODIFIERS</label>
+        </div>
+
+        {{!-- Mod 1 --}}
+        <div class="form-group">
+            <label>Mod 1</label>
+            <select name="system.mods.first.stat">
+                <option value="">- None -</option>
+                {{selectOptions @root.config.stats selected=system.mods.first.stat}}
+            </select>
+        </div>
+        <div class="form-group"><label>Value</label><input type="number" name="system.mods.first.value" value="{{system.mods.first.value}}"/></div>
+
+        {{!-- Mod 2 --}}
+        <div class="form-group">
+            <label>Mod 2</label>
+            <select name="system.mods.second.stat">
+                <option value="">- None -</option>
+                {{selectOptions @root.config.stats selected=system.mods.second.stat}}
+            </select>
+        </div>
+        <div class="form-group"><label>Value</label><input type="number" name="system.mods.second.value" value="{{system.mods.second.value}}"/></div>
+    {{/if}}
+
+</div>

--- a/templates/partials/item-dossier.hbs
+++ b/templates/partials/item-dossier.hbs
@@ -1,0 +1,71 @@
+<div class="office-dossier">
+    <div class="dossier-stamp">CONFIDENTIAL</div>
+
+    {{!-- SPECIES STATS --}}
+    {{#if (eq item.type "species")}}
+    <div class="paper-section">
+        <div class="paper-header">BIOLOGICAL DATA</div>
+        <div class="form-group paper-row">
+            <label>Base HP</label>
+            <input type="number" name="system.hp" value="{{system.hp}}"/>
+        </div>
+        <div class="form-group paper-row">
+            <label>Movement (Close / Rush)</label>
+            <div class="flexrow">
+                <input type="number" name="system.move.closing" value="{{system.move.closing}}"/> / 
+                <input type="number" name="system.move.rushing" value="{{system.move.rushing}}"/>
+            </div>
+        </div>
+        
+        <div class="paper-header" style="margin-top: 5px;">STAT LIMITS (MIN - MAX)</div>
+        <div class="stat-limits-grid">
+            {{#each system.stats as |stat key|}}
+            <div class="limit-box">
+                <label>{{upper key}}</label>
+                <div class="flexrow">
+                    <input type="number" name="system.stats.{{key}}.min" value="{{stat.min}}"/>-
+                    <input type="number" name="system.stats.{{key}}.max" value="{{stat.max}}"/>
+                </div>
+            </div>
+            {{/each}}
+        </div>
+    </div>
+    {{/if}}
+
+    {{!-- PACKAGE REQUIREMENTS --}}
+    {{#if (eq item.type "package")}}
+    <div class="paper-section">
+        <div class="paper-header">TRAINING PREREQUISITES</div>
+        <div class="stat-limits-grid">
+            {{#each system.requirements as |val key|}}
+            <div class="limit-box">
+                <label>{{upper key}}</label>
+                <input type="number" name="system.requirements.{{key}}" value="{{val}}"/>
+            </div>
+            {{/each}}
+        </div>
+    </div>
+    {{/if}}
+
+    {{!-- SKILL GRANTING DROP ZONE --}}
+    <div class="paper-section">
+        <div class="paper-header">GRANTED SKILLS</div>
+        
+        <div class="drop-zone skill-grant-area">
+            {{#each system.skills as |skill idx|}}
+                <div class="granted-skill-chip">
+                    {{!-- Image --}}
+                    <img src="{{skill.img}}" title="{{skill.name}}" width="24" height="24"/>
+                    
+                    {{!-- Name & Rank --}}
+                    <span class="skill-name">{{skill.name}} ({{skill.rank}})</span>
+                    
+                    {{!-- Delete Button --}}
+                    <a class="delete-grant" data-index="{{idx}}"><i class="fas fa-times"></i></a>
+                </div>
+            {{else}}
+                <div class="empty-dossier-text">Drag Skill Items Here</div>
+            {{/each}}
+        </div>
+    </div>
+</div>

--- a/templates/partials/item-spectral.hbs
+++ b/templates/partials/item-spectral.hbs
@@ -1,0 +1,42 @@
+<div class="spectral-container">
+    <div class="form-group glow-input">
+        <label>Flux Cost</label><input type="number" name="system.cost" value="{{system.cost}}"/>
+    </div>
+
+    {{!-- DISCIPLINE ITEM (Simple Rank) --}}
+    {{#if (eq item.type "discipline")}}
+        <div class="form-group glow-input"><label>Rank</label><input type="number" name="system.rank" value="{{system.rank}}"/></div>
+    {{/if}}
+
+    {{!-- EBB FORMULA ITEM --}}
+    {{#if (eq item.type "ebbFormula")}}
+        <div class="form-group glow-input"><label>Formula Rating</label><input type="number" name="system.formulaRating" value="{{system.formulaRating}}"/></div>
+        
+        {{!-- LINKED DISCIPLINE (Dashed Drop Zone) --}}
+        <div class="form-group" style="margin-top:10px;">
+            <label style="color:#a855f7; font-weight:bold; font-size:0.8em; margin-bottom:5px; display:block;">REQUIRED DISCIPLINE</label>
+            
+            {{!-- This container acts as the drop target --}}
+            <div class="drop-zone discipline-drop-zone linked-item">
+                {{#if system.discipline}}
+                    {{!-- Display Linked Item --}}
+                    <img src="{{linkedDisciplineImg}}"/>
+                    <span class="linked-name">{{system.discipline}}</span>
+                    <a class="remove-discipline" title="Remove Link"><i class="fas fa-times"></i></a>
+                {{else}}
+                    {{!-- Placeholder Text --}}
+                    <span class="placeholder">Drop Discipline Here</span>
+                {{/if}}
+            </div>
+            
+            {{!-- Hidden input saves the name --}}
+            <input type="hidden" name="system.discipline" value="{{system.discipline}}"/>
+        </div>
+
+        {{!-- COMBAT STATS --}}
+        <div class="catalogue-grid" style="background:transparent; border:none; padding:0; margin-top:15px;">
+             <div class="form-group glow-input"><label>Dmg</label><input type="text" name="system.damage" value="{{system.damage}}"/></div>
+             <div class="form-group glow-input"><label>Rng</label><input type="text" name="system.range" value="{{system.range}}"/></div>
+        </div>
+    {{/if}}
+</div>

--- a/templates/partials/main-tab.hbs
+++ b/templates/partials/main-tab.hbs
@@ -1,4 +1,6 @@
 <div class="flexcol full-height">
+    
+    {{!-- TOP SECTION: Split Columns --}}
     <div class="main-split">
         <div class="left-col flexcol full-height">
             <div style="flex: 1; min-height: 400px;">
@@ -11,98 +13,110 @@
         </div>
     </div>
     
-    {{!-- COMBAT LOADOUT (Weapons/Armor ONLY) --}}
+    {{!-- BOTTOM SECTION: COMBAT LOADOUT --}}
     <div class="sla-panel" style="margin-top: 5px; flex: 1; min-height: 200px;">
-        <div class="sla-header-bar">COMBAT LOADOUT (Weapons & Armor)</div>
+        <div class="sla-header-bar">COMBAT LOADOUT</div>
         <div class="scroll-list">
-            <table class="sla-table">
-                <thead>
-                    <tr>
-                        <th style="text-align:left; padding-left:5px;">Name</th>
-                        <th style="width:40px;">Eqp</th>
-                        <th style="width:100px;">Stats</th>
-                        <th style="width:110px;">Actions/Ammo</th> {{!-- WIDENED COLUMN --}}
-                        <th style="width:50px;"></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {{#each gear as |item|}}
-                        {{#if (or (eq item.type "weapon") (eq item.type "armor"))}}
-                        <tr class="item" data-item-id="{{item._id}}">
-                            <td class="item-name rollable" data-roll-type="item" style="font-weight:bold; color:#000; padding-left:5px;">
-                                <div class="flexrow" style="align-items:center;">
-                                    <img src="{{item.img}}" width="24" height="24" style="border:1px solid #000; margin-right:5px;"/>
-                                    {{item.name}}
-                                </div>
-                            </td>
-                            
-                            {{!-- EQUIP COLUMN --}}
-                            <td style="text-align:center;">
-                                <a class="item-toggle" title="{{#if item.system.equipped}}Unequip{{else}}Equip{{/if}}">
-                                    <i class="fas {{#if item.system.equipped}}fa-check-circle{{else}}fa-circle{{/if}}" style="color:{{#if item.system.equipped}}#222{{else}}#ccc{{/if}}"></i>
-                                </a>
-                            </td>
+            
+            {{!-- 1. WEAPONS GROUP --}}
+            {{#if weapons.length}}
+            <div class="group-header" style="background:#111; color:#D05E1A; font-size:0.85em; padding:2px 8px; font-weight:bold; border-bottom:1px solid #444; letter-spacing:1px;">
+                WEAPONS
+            </div>
+            <div class="combat-list">
+                {{#each weapons as |item|}}
+                <div class="item" data-item-id="{{item._id}}" style="display:flex; align-items:center; padding:4px 8px; border-bottom:1px solid #333;">
+                    
+                    {{!-- Name --}}
+                    <div class="item-name" style="flex:2; font-weight:bold; color:#e0e0e0;">
+                        <a class="item-edit">{{item.name}}</a>
+                    </div>
 
-                            {{!-- STATS COLUMN --}}
-                            <td style="text-align:center; font-size:0.9em; color:#444;">
-                                {{#if (eq item.type "weapon")}}{{item.system.damage}}{{/if}}
-                                {{#if (eq item.type "armor")}}PV: {{item.system.pv}}{{/if}}
-                            </td>
-
-                            {{!-- ACTIONS/AMMO/RESIST COLUMN --}}
-                            <td style="text-align:center;">
-                            {{!-- ARMOR STATS (NEW BLOCK) --}}
-                            {{#if (eq item.type "armor")}}
-                            <div class="flexrow armor-resist-stats" style="align-items:center; justify-content:center; gap:5px; font-size:0.9em;">
-                                <i class="fas fa-shield-alt" title="Resistance" style="color: #8a2be2;"></i>
-                                
-                                {{!-- Current Resist (Editable) --}}
-                                <input type="number" 
-                                class="inline-edit" 
-                                data-field="system.resistance.value" 
-                                data-item-id="{{item._id}}"
-                                value="{{item.system.resistance.value}}" 
-                                title="Current Resistance"
-                                style="width: 35px; height: 20px; text-align: center; border: 1px solid #555; background: rgba(0,0,0,0.3); color: #fff;"/>
-                                
-                                <span style="color: #777;">/</span>
-                                
-                                {{!-- Max Resist (Read Only) --}}
-                                <span title="Max Resistance" style="color: #aaa; font-weight: bold;">{{item.system.resistance.max}}</span>
-                            </div>
-                            {{/if}}
-
-                            {{!-- WEAPON ACTIONS (EXISTING BLOCK) --}}
-							{{#if (eq item.type "weapon")}}
-							<div class="flexrow" style="align-items:center; justify-content:center; gap:5px;">
-    
-								{{!-- 1. Attack Button (Color changed to Accent Orange) --}}
-								<a class="rollable" data-roll-type="item" title="Attack"><i class="fas fa-crosshairs" style="color:#D05E1A"></i></a>
-    
-								{{!-- 2. Reload Button (Color changed to Accent Orange) --}}
-								<a class="item-reload" title="Reload"><i class="fas fa-sync-alt" style="color:#D05E1A; font-size:0.9em;"></i></a>
-    
-								{{!-- 3. Ammo Display --}}
-								<span style="font-size:0.8em; font-weight:bold; color:{{#if (eq item.system.maxAmmo 0)}}#d00{{else}}#e0e0e0{{/if}};">
-								{{#if item.system.maxAmmo}}
-									{{item.system.ammo}}/{{item.system.maxAmmo}}
-								{{else}}
-									No Clip
-								{{/if}}
-								</span>
-							</div>
-							{{/if}}
-                            </td>
-
-                            <td class="item-controls">
-                                <a class="item-edit"><i class="fas fa-edit" style="color:#444"></i></a>
-                                <a class="item-delete"><i class="fas fa-trash" style="color:#444"></i></a>
-                            </td>
-                        </tr>
+                    {{!-- Stats & Ammo --}}
+                    <div class="item-detail" style="flex:1.5; text-align:center; font-size:0.9em; color:#aaa; display:flex; justify-content:center; gap:10px;">
+                        <span style="color:#fff;" title="Damage">{{item.system.damage}}</span>
+                        
+                        {{!-- AMMO COUNTER FIX --}}
+                        {{!-- Checks if maxAmmo exists (is a gun that has been loaded/initialized) --}}
+                        {{#if item.system.maxAmmo}}
+                            <span style="font-family:'Courier New', monospace; font-weight:bold; {{#if (eq item.system.ammo 0)}}color:#ff5555;{{else}}color:#888;{{/if}}">
+                                [{{item.system.ammo}}/{{item.system.maxAmmo}}]
+                            </span>
                         {{/if}}
-                    {{/each}}
-                </tbody>
-            </table>
+                    </div>
+
+                    {{!-- Controls --}}
+                    <div class="item-controls" style="flex:0 0 90px; text-align:right; display:flex; justify-content:flex-end; gap:8px;">
+                        {{!-- Attack --}}
+                        <a class="rollable" data-roll-type="item" title="Attack">
+                            <i class="fas fa-crosshairs" style="color:#D05E1A"></i>
+                        </a>
+                        
+                        {{!-- Reload (Always visible for weapons) --}}
+                        <a class="item-reload" title="Reload">
+                            <i class="fas fa-sync-alt" style="color:#aaa;"></i>
+                        </a>
+
+                        {{!-- Equip (Green Checkmark Fix) --}}
+                        <a class="item-toggle" title="Equip/Holster">
+                            {{#if item.system.equipped}}
+                                <i class="fas fa-check-circle" style="color:#39ff14;"></i> {{!-- Neon Green --}}
+                            {{else}}
+                                <i class="fas fa-circle" style="color:#444;"></i>
+                            {{/if}}
+                        </a>
+                    </div>
+                </div>
+                {{/each}}
+            </div>
+            {{/if}}
+
+            {{!-- 2. ARMOR GROUP --}}
+            {{#if armors.length}}
+            <div class="group-header" style="background:#111; color:#D05E1A; font-size:0.85em; padding:2px 8px; font-weight:bold; border-bottom:1px solid #444; margin-top:5px; letter-spacing:1px;">
+                ARMOR
+            </div>
+            <div class="combat-list">
+                {{#each armors as |item|}}
+                <div class="item" data-item-id="{{item._id}}" style="display:flex; align-items:center; padding:4px 8px; border-bottom:1px solid #333;">
+                    
+                    {{!-- Name --}}
+                    <div class="item-name" style="flex:2; font-weight:bold; color:#e0e0e0;">
+                        <a class="item-edit">{{item.name}}</a>
+                    </div>
+
+                    {{!-- Stats & Inline Edit --}}
+                    <div class="item-detail" style="flex:1.5; display:flex; align-items:center; justify-content:center; gap:10px; font-size:0.9em; color:#aaa;">
+                        <span>PV: {{item.system.pv}}</span>
+                        
+                        {{!-- Resistance Input --}}
+                        <div style="display:flex; align-items:center; gap:3px;">
+                            <i class="fas fa-shield-alt" style="color:#8a2be2; font-size:0.8em;"></i>
+                            <input type="number" 
+                                   class="inline-edit" 
+                                   data-field="system.resistance.value" 
+                                   data-item-id="{{item._id}}"
+                                   value="{{item.system.resistance.value}}" 
+                                   style="width:30px; height:20px; text-align:center; background:#222; border:1px solid #555; color:#fff;" />
+                            <span>/ {{item.system.resistance.max}}</span>
+                        </div>
+                    </div>
+
+                    {{!-- Controls --}}
+                    <div class="item-controls" style="flex:0 0 40px; text-align:right;">
+                        <a class="item-toggle" title="Wear/Remove">
+                            {{#if item.system.equipped}}
+                                <i class="fas fa-check-circle" style="color:#39ff14;"></i>
+                            {{else}}
+                                <i class="fas fa-circle" style="color:#444;"></i>
+                            {{/if}}
+                        </a>
+                    </div>
+                </div>
+                {{/each}}
+            </div>
+            {{/if}}
+
         </div>
     </div>
 </div>

--- a/templates/partials/wounds.hbs
+++ b/templates/partials/wounds.hbs
@@ -1,35 +1,67 @@
-<div class="sla-panel" style="flex: 0 0 auto;">
-    <div class="sla-header-bar">WOUNDS</div>
+<div class="sla-panel">
+    <div class="sla-header-bar">STATUS & WOUNDS</div>
     
-    <div class="wound-list">
+    <div class="sla-pad">
         
-        {{!-- Top Row --}}
-        <div class="wound-entry"><label for="head-wound">Head</label><input type="checkbox" name="system.wounds.head" id="head-wound" {{checked system.wounds.head}} class="wound-checkbox"/></div>
-        <div class="wound-entry"><label for="torso-wound">Torso</label><input type="checkbox" name="system.wounds.torso" id="torso-wound" {{checked system.wounds.torso}} class="wound-checkbox"/></div>
+        {{!-- Wounds Grid (Explicitly Defined) --}}
+        <div class="wound-list">
+            {{!-- HEAD --}}
+            <div class="wound-entry">
+                <label for="wound-head">Head</label>
+                <input type="checkbox" class="wound-checkbox" id="wound-head" name="system.wounds.head" {{checked system.wounds.head}}/>
+            </div>
+            {{!-- TORSO --}}
+            <div class="wound-entry">
+                <label for="wound-torso">Torso</label>
+                <input type="checkbox" class="wound-checkbox" id="wound-torso" name="system.wounds.torso" {{checked system.wounds.torso}}/>
+            </div>
 
-        {{!-- Middle Row --}}
-        <div class="wound-entry"><label for="larm-wound">Left Arm</label><input type="checkbox" name="system.wounds.larm" id="larm-wound" {{checked system.wounds.larm}} class="wound-checkbox"/></div>
-        <div class="wound-entry"><label for="rarm-wound">Right Arm</label><input type="checkbox" name="system.wounds.rarm" id="rarm-wound" {{checked system.wounds.rarm}} class="wound-checkbox"/></div>
+            {{!-- LEFT ARM --}}
+            <div class="wound-entry">
+                <label for="wound-larm">Left Arm</label>
+                <input type="checkbox" class="wound-checkbox" id="wound-larm" name="system.wounds.larm" {{checked system.wounds.larm}}/>
+            </div>
+            {{!-- RIGHT ARM --}}
+            <div class="wound-entry">
+                <label for="wound-rarm">Right Arm</label>
+                <input type="checkbox" class="wound-checkbox" id="wound-rarm" name="system.wounds.rarm" {{checked system.wounds.rarm}}/>
+            </div>
 
-        {{!-- Bottom Row --}}
-        <div class="wound-entry"><label for="lleg-wound">Left Leg</label><input type="checkbox" name="system.wounds.lleg" id="lleg-wound" {{checked system.wounds.lleg}} class="wound-checkbox"/></div>
-        <div class="wound-entry"><label for="rleg-wound">Right Leg</label><input type="checkbox" name="system.wounds.rleg" id="rleg-wound" {{checked system.wounds.rleg}} class="wound-checkbox"/></div>
-
-    </div>
-
-{{!-- CONDITIONS SECTION (Follows Wounds) --}}
-    <div class="section-title" style="margin-top: 10px;">CONDITIONS</div>
-    <div class="condition-grid">
-        <a class="condition-toggle {{#if system.conditions.bleeding}}active{{/if}}" data-condition="bleeding" title="Bleeding"><i class="fas fa-tint"></i></a>
-        <a class="condition-toggle {{#if system.conditions.burning}}active{{/if}}" data-condition="burning" title="Burning"><i class="fas fa-fire"></i></a>
-        <a class="condition-toggle {{#if system.conditions.prone}}active{{/if}}" data-condition="prone" title="Prone (-1 All)"><i class="fas fa-procedures"></i></a> 
-		<a class="condition-toggle {{#if system.conditions.stunned}}active{{/if}}" data-condition="stunned" title="Stunned (-1 All)"><i class="fas fa-dizzy"></i></a>
-        <a class="condition-toggle {{#if system.conditions.immobile}}active{{/if}}" data-condition="immobile" title="Immobile (0 MVT)"><i class="fas fa-hand-paper"></i></a>
-        
-        
-        {{!-- CRITICAL STATUS (READ-ONLY) --}}
-        <div class="condition-read-only {{#if system.conditions.critical}}active{{/if}}" title="Critical Wound Penalty">
-            <i class="fas fa-skull-crossbones"></i>
+            {{!-- LEFT LEG --}}
+            <div class="wound-entry">
+                <label for="wound-lleg">Left Leg</label>
+                <input type="checkbox" class="wound-checkbox" id="wound-lleg" name="system.wounds.lleg" {{checked system.wounds.lleg}}/>
+            </div>
+            {{!-- RIGHT LEG --}}
+            <div class="wound-entry">
+                <label for="wound-rleg">Right Leg</label>
+                <input type="checkbox" class="wound-checkbox" id="wound-rleg" name="system.wounds.rleg" {{checked system.wounds.rleg}}/>
+            </div>
         </div>
+
+        {{!-- Conditions Grid --}}
+        <div class="condition-grid">
+            <a class="condition-toggle {{#if system.conditions.prone}}active{{/if}}" data-condition="prone" title="Prone">
+                <i class="fas fa-user-injured"></i>
+            </a>
+            <a class="condition-toggle {{#if system.conditions.stunned}}active{{/if}}" data-condition="stunned" title="Stunned">
+                <i class="fas fa-dizzy"></i>
+            </a>
+            <a class="condition-toggle {{#if system.conditions.burning}}active{{/if}}" data-condition="burning" title="Burning">
+                <i class="fas fa-fire"></i>
+            </a>
+            <a class="condition-toggle {{#if system.conditions.bleeding}}active{{/if}}" data-condition="bleeding" title="Bleeding">
+                <i class="fas fa-tint"></i>
+            </a>
+            <a class="condition-toggle {{#if system.conditions.immobile}}active{{/if}}" data-condition="immobile" title="Immobile">
+                <i class="fas fa-lock"></i>
+            </a>
+
+            {{!-- Critical Status (Skull Icon) --}}
+            <a class="condition-toggle {{#if system.conditions.critical}}active{{/if}}" data-condition="critical" title="Critical Status">
+                <i class="fas fa-skull"></i>
+            </a>
+        </div>
+
     </div>
 </div>


### PR DESCRIPTION
Refactored CSS for item sheet themes, introducing more specific and modular theme classes for catalogue, academic, spectral, and dossier item types. Improved actor sheet layout, header, and stat strip styling for clarity and usability. Added new partial templates for item subtypes and bio/gear tabs, and updated Handlebars templates to use these partials. Adjusted item and actor sheet JavaScript to support new layouts and tab structures.