### PR TITLE
Add reload logic for weapons and update combat loadout

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -82,6 +82,7 @@ _prepareItems(context) {
     const traits = [];
     const ebbFormulas = [];
     const disciplines = [];
+    const skills = [];
     
     // Skill Buckets
     const skillsByStat = {
@@ -94,7 +95,7 @@ _prepareItems(context) {
         "other": { label: "OTHER", items: [] }
     };
 
-    // Separate Arrays for Combat Tab (Weapons/Armor only)
+    // Separate Arrays for Combat Tab
     const weapons = [];
     const armors = [];
 
@@ -108,7 +109,15 @@ _prepareItems(context) {
       }
 
       // COMBAT TAB SPECIFIC
-      if (i.type === 'weapon') weapons.push(i);
+      if (i.type === 'weapon') {
+          // --- NEW: RELOAD LOGIC ---
+          // Hide reload button if skill is melee or unarmed
+          const skillKey = (i.system.skill || "").toLowerCase();
+          i.isReloadable = !["melee", "unarmed"].includes(skillKey);
+          
+          weapons.push(i);
+      }
+      
       if (i.type === 'armor') armors.push(i);
 
       // OTHER ITEMS
@@ -120,6 +129,7 @@ _prepareItems(context) {
           const stat = (i.system.stat || "dex").toLowerCase();
           if (skillsByStat[stat]) skillsByStat[stat].items.push(i);
           else skillsByStat["other"].items.push(i);
+          skills.push(i);
       }
     }
 
@@ -133,6 +143,7 @@ _prepareItems(context) {
     disciplines.sort(sortFn);
     weapons.sort(sortFn);
     armors.sort(sortFn);
+    skills.sort(sortFn);
     
     for (const key in skillsByStat) {
         skillsByStat[key].items.sort(sortFn);
@@ -155,14 +166,14 @@ _prepareItems(context) {
     });
 
     // 5. Assign to Context
-    context.inventory = inventory; // <--- The new grouped object
+    context.inventory = inventory; 
     context.traits = traits;
     context.disciplines = nestedDisciplines;
     context.skillsByStat = skillsByStat;
     
-    // For Combat Tab
     context.weapons = weapons;
     context.armors = armors;
+    context.skills = skills;
   }
 
   /* -------------------------------------------- */

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "0.3.6-alpha",
+  "version": "0.3.7-alpha",
   "compatibility": {
     "minimum": "13",
     "verified": "13.351"
@@ -29,5 +29,5 @@
   "secondaryTokenAttribute": "attributes.flux",
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.3.6/sla-foundry.zip"
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.3.7/sla-foundry.zip"
 }

--- a/templates/partials/combat-loadout.hbs
+++ b/templates/partials/combat-loadout.hbs
@@ -33,9 +33,12 @@
                         <i class="fas fa-crosshairs" style="color:#D05E1A"></i>
                     </a>
                     
+                    {{!-- RELOAD: Only show if NOT Melee/Unarmed --}}
+                    {{#if item.isReloadable}}
                     <a class="item-reload" title="Reload">
                         <i class="fas fa-sync-alt" style="color:#aaa;"></i>
                     </a>
+                    {{/if}}
 
                     <a class="item-toggle" title="Equip/Holster">
                         {{#if item.system.equipped}}


### PR DESCRIPTION
Introduces logic to hide the reload button for melee and unarmed weapons in the combat loadout. Updates the actor sheet to flag weapons as reloadable based on their associated skill, and passes this information to the template. Also bumps the system version to 0.3.7-alpha in system.json.