### PR TITLE
Add ammo type selector to magazine items

### DIFF
--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "0.3.7-alpha",
+  "version": "0.3.8-alpha",
   "compatibility": {
     "minimum": "13",
     "verified": "13.351"
@@ -29,5 +29,5 @@
   "secondaryTokenAttribute": "attributes.flux",
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.3.7/sla-foundry.zip"
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.3.8/sla-foundry.zip"
 }

--- a/templates/partials/item-catalogue.hbs
+++ b/templates/partials/item-catalogue.hbs
@@ -37,11 +37,32 @@
     
     {{!-- MAGAZINE --}}
     {{#if (eq item.type "magazine")}}
-        <div class="form-group" style="grid-column: 1 / -1;"><label>Capacity</label><input type="number" name="system.ammoCapacity" value="{{system.ammoCapacity}}"/></div>
+        {{!-- Capacity --}}
+        <div class="form-group" style="grid-column: 1 / -1;">
+            <label>Capacity</label>
+            <input type="number" name="system.ammoCapacity" value="{{system.ammoCapacity}}" placeholder="10"/>
+        </div>
+
+        {{!-- NEW: AMMO TYPE SELECTOR --}}
+        <div class="form-group" style="grid-column: 1 / -1;">
+            <label>Ammo Type</label>
+            <select name="system.ammoType">
+                <option value="">- Select Type -</option>
+                {{!-- Pulls from config.mjs --}}
+                {{selectOptions @root.config.ammoTypes selected=system.ammoType localize=false}}
+            </select>
+        </div>
+
+        {{!-- Linked Weapon --}}
         <div class="form-group" style="grid-column: 1 / -1;">
              <label>Linked:</label>
-             <div class="drop-zone weapon-link" style="border:1px dashed #555; padding:5px;">
-                 {{#if system.linkedWeapon}}<b>{{system.linkedWeapon}}</b> <a class="remove-link"><i class="fas fa-times"></i></a>{{else}}Drop Weapon Here{{/if}}
+             <div class="drop-zone weapon-link" style="border:1px dashed #555; padding:5px; display:flex; align-items:center; justify-content:center; cursor:pointer;">
+                 {{#if system.linkedWeapon}}
+                    <b>{{system.linkedWeapon}}</b> 
+                    <a class="remove-link" style="margin-left:5px; color:#d00;"><i class="fas fa-times"></i></a>
+                 {{else}}
+                    <span style="color:#777; font-style:italic;">Drop Weapon Here</span>
+                 {{/if}}
              </div>
         </div>
     {{/if}}


### PR DESCRIPTION
Introduces an ammo type dropdown for magazine items in the item catalogue template, allowing users to select from configured ammo types. Also improves the linked weapon UI and updates system version to 0.3.8-alpha.