### PR TITLE
Refactor chat damage result to use Handlebars template

### DIFF
--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -26,6 +26,7 @@ export const preloadHandlebarsTemplates = async function() {
   "systems/sla-industries/templates/partials/item-spectral.hbs",
   "systems/sla-industries/templates/partials/item-dossier.hbs",
   "systems/sla-industries/templates/partials/combat-tab.hbs",
+  "systems/sla-industries/templates/chat/chat-damage-result.hbs",
   "systems/sla-industries/templates/partials/combat-loadout.hbs"
   ];
 

--- a/templates/chat/chat-damage-result.hbs
+++ b/templates/chat/chat-damage-result.hbs
@@ -1,0 +1,25 @@
+<div class="sla-chat-card" style="background:#330000; color:#fff; padding:5px; border:1px solid #d00; font-family:'Roboto Condensed';">
+    <div style="font-size:1.1em; font-weight:bold; border-bottom:1px solid #d00; margin-bottom:4px;">
+        {{victimName}} Hit!
+    </div>
+    
+    <div style="display:flex; justify-content:space-between;">
+        <span>Raw Damage:</span> <strong>{{rawDamage}}</strong>
+    </div>
+    <div style="display:flex; justify-content:space-between; color:#ffaaaa;">
+        <span>PV Reduction:</span> <strong>-{{targetPV}}</strong>
+    </div>
+    <div style="display:flex; justify-content:space-between; border-top:1px solid #d00; margin-top:2px; padding-top:2px;">
+        <span>Final HP Loss:</span> <strong style="color:#ff5555; font-size:1.2em;">{{finalDamage}}</strong>
+    </div>
+    
+    <div style="text-align:right; font-size:0.9em; margin-top:5px; color:#ccc;">
+        HP: {{hpData.old}} &rarr; <strong>{{hpData.new}}</strong>
+    </div>
+
+    {{#if armorData}}
+    <div style="font-size:0.8em; color:#aaa; margin-top:2px;">
+        <i class="fas fa-shield-alt"></i> Armor Res: {{armorData.current}} &rarr; {{armorData.new}} (-{{armorData.ad}})
+    </div>
+    {{/if}}
+</div>


### PR DESCRIPTION
Moved the chat message for damage results to a new Handlebars template (chat-damage-result.hbs) for improved maintainability and clarity. Updated the logic to pass structured data to the template instead of building HTML strings in JavaScript.