### PR TITLE
Add custom appearance to success dice in rolls

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -397,6 +397,16 @@ async _onRoll(event) {
         const finalMod = statValue - penalty + globalMod;
 
         let roll = new Roll("1d10");
+		// --- DICE SO NICE: FORCE BLACK SUCCESS DIE ---
+		// Target the first term (1d10)
+		if (roll.terms.length > 0 && roll.terms[0].constructor.name === "Die") {
+          roll.terms[0].options.appearance = {
+              foreground: "#FFFFFF", // White Text
+              background: "#000000", // Black Body
+              edge: "#333333"        // Dark Grey Outline
+          };
+		}
+		// ---------------------------------------------
         await roll.evaluate();
         
         let rawDie = roll.terms[0].results[0].result;
@@ -481,6 +491,16 @@ async _onRoll(event) {
       const rollFormula = `1d10 + ${skillDiceCount}d10`;
 
       let roll = new Roll(rollFormula);
+	  // --- DICE SO NICE: FORCE BLACK SUCCESS DIE ---
+		// Target the first term (1d10)
+		if (roll.terms.length > 0 && roll.terms[0].constructor.name === "Die") {
+          roll.terms[0].options.appearance = {
+              foreground: "#FFFFFF", // White Text
+              background: "#000000", // Black Body
+              edge: "#333333"        // Dark Grey Outline
+          };
+		}
+		// ---------------------------------------------
       await roll.evaluate();
 
       // 4. CALCULATE SUCCESS
@@ -616,6 +636,16 @@ async _processWeaponRoll(item, html, isMelee) {
       const rollFormula = `1d10 + ${skillDiceCount}d10`;
       
       let roll = new Roll(rollFormula);
+	  // --- DICE SO NICE: FORCE BLACK SUCCESS DIE ---
+		// Target the first term (1d10)
+		if (roll.terms.length > 0 && roll.terms[0].constructor.name === "Die") {
+          roll.terms[0].options.appearance = {
+              foreground: "#FFFFFF", // White Text
+              background: "#000000", // Black Body
+              edge: "#333333"        // Dark Grey Outline
+          };
+		}
+		// ---------------------------------------------
       await roll.evaluate();
 
       // 5. RESULTS
@@ -768,6 +798,16 @@ async _processWeaponRoll(item, html, isMelee) {
       const rollFormula = `1d10 + ${skillDiceCount}d10`;
 
       let roll = new Roll(rollFormula);
+	  // --- DICE SO NICE: FORCE BLACK SUCCESS DIE ---
+		// Target the first term (1d10)
+		if (roll.terms.length > 0 && roll.terms[0].constructor.name === "Die") {
+          roll.terms[0].options.appearance = {
+              foreground: "#FFFFFF", // White Text
+              background: "#000000", // Black Body
+              edge: "#333333"        // Dark Grey Outline
+          };
+		}
+		// ---------------------------------------------
       await roll.evaluate();
 
       // 5. Calculate Success (Target Number is the Formula Rating)

--- a/module/sla-industries.mjs
+++ b/module/sla-industries.mjs
@@ -99,6 +99,8 @@ Handlebars.registerHelper('or', function (a, b) { return a || b; });
 Handlebars.registerHelper('gt', function (a, b) { return a > b; });
 Handlebars.registerHelper('and', function (a, b) { return a && b; });
 
+
+
 /* -------------------------------------------- */
 /* Global Listeners (Rolling & Applying Damage) */
 /* -------------------------------------------- */


### PR DESCRIPTION
Applied a black background with white text and dark grey edge to the first d10 die in relevant roll formulas for better visual distinction using Dice So Nice. This affects all actor and weapon roll methods where a success die is present.