### PR TITLE
Fix sheet crash on species/package removal

### DIFF
--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "0.4.2-alpha",
+  "version": "0.4.3-alpha",
   "compatibility": {
     "minimum": "13",
     "verified": "13.351"
@@ -29,5 +29,5 @@
   "secondaryTokenAttribute": "attributes.flux",
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.4.2/sla-foundry.zip"
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.4.3/sla-foundry.zip"
 }


### PR DESCRIPTION
Prevents the actor sheet from crashing when removing species or package items by deferring sheet re-render until all related items are deleted. Also refactors event listeners for better maintainability and updates system version to 0.4.3-alpha.