### PR TITLE
Add drug consumption feature and update drug item fields

### DIFF
--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "0.5.0-alpha",
+  "version": "0.6.0-alpha",
   "compatibility": {
     "minimum": "13",
     "verified": "13.351"
@@ -29,7 +29,7 @@
   "secondaryTokenAttribute": "attributes.flux",
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.5.0/sla-foundry.zip"
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.6.0/sla-foundry.zip"
 
 
 }

--- a/template.json
+++ b/template.json
@@ -193,16 +193,14 @@
     },
     "drug": {
       "templates": ["base"],
-      "duration": 1,
-      "addiction": 10,
       "price": 50,
       "weight": 0.1,
       "quantity": 1,
-      "mods": {
-        "first": { "stat": "", "value": 0 },
-        "second": { "stat": "", "value": 0 }
-      },
-      "active": false,
+      "equipped": false,
+      "addiction": 10,          
+      "addictionDose": "",      
+      "detoxEffects": "",       
+      "duration": "",           
       "description": ""
     },
     "species": {

--- a/templates/partials/inventory-tab.hbs
+++ b/templates/partials/inventory-tab.hbs
@@ -47,6 +47,11 @@
 
                         {{!-- CONTROLS --}}
                         <td class="item-controls" style="text-align:right; padding-right:5px;">
+                            {{!-- NEW: Only show Syringe for Drug items --}}
+                            {{#if (eq item.type "drug")}}
+                                <a class="item-control item-use-drug" title="Consume Dose"><i class="fas fa-syringe" style="color:#d05e1a; margin-right:5px;"></i></a>
+                            {{/if}}
+
                             <a class="item-edit" title="Edit Item"><i class="fas fa-edit" style="color:#444;"></i></a>
                             <a class="item-delete" title="Delete Item"><i class="fas fa-trash" style="color:#444;"></i></a>
                         </td>

--- a/templates/partials/item-drug.hbs
+++ b/templates/partials/item-drug.hbs
@@ -1,27 +1,30 @@
-<div class="form-group"><label>Duration</label><input type="number" name="system.duration" value="{{system.duration}}"/></div>
-<div class="form-group"><label>Addiction</label><input type="number" name="system.addiction" value="{{system.addiction}}"/></div>
+<div class="sla-panel" style="background-color: #000; color: #e0e0e0; padding: 5px;">
+    
+    {{!-- Top Row: Addiction Rating & Duration --}}
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 10px;">
+        <div class="form-group">
+            <label style="color:var(--sla-accent);">Addiction Rating</label>
+            <input type="number" name="system.addiction" value="{{system.addiction}}" placeholder="10"/>
+        </div>
+        <div class="form-group">
+            <label style="color:var(--sla-accent);">Duration</label>
+            <input type="text" name="system.duration" value="{{system.duration}}" placeholder="e.g. 4 Hours"/>
+        </div>
+    </div>
 
-{{!-- Section Header --}}
-<div class="form-group" style="grid-column: 1 / -1; margin-top: 10px; border-top: 2px solid #555; padding-top: 5px;">
-    <label style="width:100%; text-align:center;">STAT MODIFIERS</label>
-</div>
+    {{!-- Addiction Dose --}}
+    <div class="form-group" style="flex-direction: column; align-items: flex-start; margin-bottom: 8px;">
+        <label style="color:var(--sla-accent); margin-bottom: 2px;">Addiction Dose</label>
+        <input type="text" name="system.addictionDose" value="{{system.addictionDose}}" placeholder="e.g. Every 6 hours plus every combat..."/>
+    </div>
 
-{{!-- Mod 1 --}}
-<div class="form-group">
-    <label>Mod 1</label>
-    <select name="system.mods.first.stat">
-        <option value="">- None -</option>
-        {{selectOptions @root.config.stats selected=system.mods.first.stat}}
-    </select>
-</div>
-<div class="form-group"><label>Value</label><input type="number" name="system.mods.first.value" value="{{system.mods.first.value}}"/></div>
+    {{!-- Detox Effects --}}
+    <div class="form-group" style="flex-direction: column; align-items: flex-start;">
+        <label style="color:var(--sla-accent); margin-bottom: 2px;">Detox Effects</label>
+        <textarea name="system.detoxEffects" rows="3" style="width:100%; background:#111; color:#fff; border:1px solid #444; resize:vertical;">{{system.detoxEffects}}</textarea>
+    </div>
 
-{{!-- Mod 2 --}}
-<div class="form-group">
-    <label>Mod 2</label>
-    <select name="system.mods.second.stat">
-        <option value="">- None -</option>
-        {{selectOptions @root.config.stats selected=system.mods.second.stat}}
-    </select>
+    <div style="margin-top: 10px; font-size: 0.8em; color: #777; text-align: center; font-style: italic;">
+        Drug effects are managed manually via the Description tab.
+    </div>
 </div>
-<div class="form-group"><label>Value</label><input type="number" name="system.mods.second.value" value="{{system.mods.second.value}}"/></div>


### PR DESCRIPTION
Introduces a clickable syringe icon for drug items in inventory, allowing users to consume a dose and automatically update or delete the item. Drug item fields are restructured for clarity, with new fields for addiction dose, detox effects, and duration, and the item-drug template is redesigned for improved usability. Version bumped to 0.6.0-alpha.