### PR TITLE
Fix editor visibility and update notes section

### DIFF
--- a/css/sla-industries.css
+++ b/css/sla-industries.css
@@ -1329,3 +1329,15 @@ form.sla-sheet {
     text-transform: uppercase;
     letter-spacing: 1px;
 }
+
+/* Fix for Invisible Editors */
+.sla-editor-container .editor {
+    height: 100%;
+    min-height: 200px; /* Fallback specific height */
+}
+
+.sla-editor-container .prosemirror {
+    height: 100%;
+    color: #e0e0e0;
+    padding: 5px;
+}

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "0.6.0-alpha",
+  "version": "0.6.1-alpha",
   "compatibility": {
     "minimum": "13",
     "verified": "13.351"
@@ -29,7 +29,7 @@
   "secondaryTokenAttribute": "attributes.flux",
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.6.0/sla-foundry.zip"
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.6.1/sla-foundry.zip"
 
 
 }

--- a/templates/partials/bio-traits-tab.hbs
+++ b/templates/partials/bio-traits-tab.hbs
@@ -34,11 +34,12 @@
         </div>
     </div>
 
-    {{!-- Notes (Updated with Title Bar) --}}
+    {{!-- Notes Section --}}
     <div class="sla-panel" style="flex: 1; min-height: 300px; display: flex; flex-direction: column;">
         <div class="sla-header-bar">NOTES</div>
-        <div class="editor-container" style="flex: 1; border: none; padding: 5px; background: #000;">
-            {{editor enrichedBiography target="system.biography" button=true owner=owner editable=editable}}
+        {{!-- Added class 'sla-editor-container' and forced height --}}
+        <div class="sla-editor-container" style="flex: 1; height: 100%; border: none; padding: 5px; background: #000;">
+            {{editor enrichedNotes target="system.notes" engine="prosemirror" button=true owner=owner editable=editable}}
         </div>
     </div>
 </div>


### PR DESCRIPTION
Added CSS rules to ensure editors are visible and styled correctly. Updated the bio traits tab to use a new 'sla-editor-container' class and switched the notes editor to use the 'prosemirror' engine. Bumped system version to 0.6.1-alpha in system.json.