### PR TITLE
Improve condition syncing and wounds logic - add resistance to NPC

### DIFF
--- a/css/sla-industries.css
+++ b/css/sla-industries.css
@@ -554,6 +554,7 @@ form.sla-sheet {
 .condition-toggle[data-condition="burning"].active { color: #ffaa00; border-color: #ffaa00; box-shadow: 0 0 8px rgba(255,170,0,0.4); text-shadow: 0 0 5px #ffaa00; }
 .condition-toggle[data-condition="stunned"].active { color: #ffff00; border-color: #ffff00; box-shadow: 0 0 8px rgba(255,255,0,0.4); text-shadow: 0 0 5px #ffff00; }
 .condition-toggle[data-condition="immobile"].active { color: #00ccff; border-color: #00ccff; box-shadow: 0 0 8px rgba(0,204,255,0.4); text-shadow: 0 0 5px #00ccff; }
+.condition-toggle[data-condition="prone"].active { color: #39ff14; border-color: #39ff14; box-shadow: 0 0 8px rgba(57,255,20,0.4); text-shadow: 0 0 5px #39ff14; }
 
 /* CRITICAL BUTTON (New Skull) */
 .condition-toggle[data-condition="critical"].active { 

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "0.6.1-alpha",
+  "version": "0.6.2-alpha",
   "compatibility": {
     "minimum": "13",
     "verified": "13.351"
@@ -29,7 +29,7 @@
   "secondaryTokenAttribute": "attributes.flux",
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.6.1/sla-foundry.zip"
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/v0.6.2/sla-foundry.zip"
 
 
 }

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -5,18 +5,6 @@
         <div class="header-name">
             <input name="name" type="text" value="{{actor.name}}" placeholder="Threat Name"/>
         </div>
-        
-        <div style="display:flex; align-items:center;">
-            {{!-- CRITICAL TOGGLE BUTTON --}}
-            <a class="condition-toggle {{#if system.conditions.critical}}active{{/if}}" 
-               data-condition="critical" 
-               title="Critical Status"
-               style="margin-right:10px; font-size:1.5em; color:{{#if system.conditions.critical}}#ff0000{{else}}#555{{/if}};">
-                <i class="fas fa-skull"></i>
-            </a>
-
-            <img class="threat-img profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}"/>
-        </div>
     </div>
 
     {{!-- STATS BLOCK --}}
@@ -72,6 +60,9 @@
             </div>
         </div>
 
+		{{!-- 1. WOUNDS & CONDITIONS PARTIAL --}}
+        {{> "systems/sla-industries/templates/partials/wounds.hbs"}}
+		
 		{{!-- 1. SKILLS SECTION --}}
         <div class="threat-section-bar">SKILLS</div>
         
@@ -137,11 +128,31 @@
 
             {{!-- ARMOR --}}
             {{#each armors as |item|}}
-            <div class="item threat-item flexrow" data-item-id="{{item._id}}">
+            <div class="item threat-item flexrow" data-item-id="{{item._id}}" style="align-items: center; padding: 2px 0;">
                 <span class="item-name" style="font-weight:bold;">{{item.name}}</span>
+                
                 {{!-- Stats Display --}}
-                <span style="color:#333; margin-left:5px; font-style:italic;">
-                    (PV: {{item.system.pv}}, Res: {{item.system.resistance.value}})
+                <span style="color:#333; margin-left:8px; font-size: 0.9em; display: flex; align-items: center;">
+                    <span style="font-style:italic; margin-right:5px;">(PV: {{item.system.pv}})</span>
+                    
+                    {{!-- Resistance Inputs --}}
+                    <label style="font-weight:bold; margin-right:3px;">Res:</label>
+                    
+                    {{!-- Current --}}
+                    <input class="inline-edit" 
+                           data-field="system.resistance.value" 
+                           type="number" 
+                           value="{{item.system.resistance.value}}" 
+                           title="Current Resistance"
+                           style="width:28px; height: 18px; text-align:center; border:1px solid #888; border-radius:3px; font-size:0.9em; background: rgba(255,255,255,0.5); margin: 0 2px;">
+                    /
+                    {{!-- Max --}}
+                    <input class="inline-edit" 
+                           data-field="system.resistance.max" 
+                           type="number" 
+                           value="{{item.system.resistance.max}}" 
+                           title="Max Resistance"
+                           style="width:28px; height: 18px; text-align:center; border:1px solid #888; border-radius:3px; font-size:0.9em; background: rgba(255,255,255,0.5); margin-left: 2px;">
                 </span>
                 
                 <div class="item-controls" style="margin-left:auto;">


### PR DESCRIPTION
Refactors condition syncing to only update changed statuses, adds sheet logic to reflect active effects, and fixes wound/bleeding checkbox state issues. Updates CSS for 'prone' condition, enhances NPC sheet with wounds/conditions partial, and allows inline editing of armor resistance. Bumps system version to 0.6.2-alpha.