### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/foundry_manifest_update.yml
+++ b/.github/workflows/foundry_manifest_update.yml
@@ -5,6 +5,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   update_foundry_website_post_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/VacantFanatic/sla-foundry/security/code-scanning/1](https://github.com/VacantFanatic/sla-foundry/security/code-scanning/1)

Add an explicit `permissions` block to the workflow (or specific job) to enforce least privilege for `GITHUB_TOKEN`.  
Best minimal fix without changing behavior assumptions is to set workflow-level permissions to `contents: read`, matching CodeQL’s recommended starting point.

In `.github/workflows/foundry_manifest_update.yml`, insert:

```yml
permissions:
  contents: read
```

directly after the `on:` trigger section (before `jobs:`). This applies to all jobs unless overridden and satisfies the CodeQL requirement for explicit token scoping.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
