### PR TITLE
Release 2.5.1 — Cursor Cloud dev environment and E2E tooling

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "install": "npm install && npm run test:e2e:install && bash scripts/cloud-foundry.sh prepare",
+  "start": "sudo service docker start 2>/dev/null || true; bash scripts/cloud-foundry.sh start || true"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ node_modules/
 /playwright/.cache/
 
 .agent/
-.cursor/
+.cursor/*
+!.cursor/environment.json
 .docs/
 .vscode/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,21 @@ There is **no** `npm run lint` script or ESLint config; format with Prettier loc
 
 ### Foundry (required for E2E and real UI testing)
 
+#### Why other agents have Foundry but this chat skipped it
+
+Foundry is **not** bundled in the repo. Other cloud agents usually have one of:
+
+1. **Workspace secrets** in [Cursor → Cloud Agents → Secrets](https://cursor.com/dashboard/cloud-agents) (persists across runs; preferred)
+2. A **saved VM snapshot** taken after Foundry was installed and licensed once
+3. A cached `foundryvtt-*.zip` under `/home/ubuntu/foundry-data/container_cache/` from a prior install
+
+Skipping secrets in a single chat prompt does **not** add them to the workspace. Add them in the dashboard, then re-run the agent or call `bash scripts/cloud-foundry.sh start`.
+
+This repo includes `.cursor/environment.json` so new agents run `scripts/cloud-foundry.sh` on boot when secrets exist.
+
 #### Cursor Cloud secrets
 
-Configure these in the agent environment (one download method is enough):
+Configure these in **Cloud Agents → Secrets** (one download method is enough):
 
 | Secret | Purpose |
 |--------|---------|
@@ -74,5 +86,12 @@ npm run test:e2e:operators
 - Playwright does **not** start Foundry; the server must already be listening on `FOUNDRY_URL`.
 - After SCSS changes, run `npm run build` — hot reload is via Foundry refresh (F5), not Vite.
 - Foundry toast notifications can block Playwright clicks; tests use `dismissFoundryNotifications()` in `tests/e2e/fixtures.js`.
+
+### Environment verification
+
+```bash
+npm run test:env    # build + unit tests; E2E if Foundry is listening
+bash scripts/cloud-foundry.sh status
+```
 
 See `DEVELOPER.md` for architecture, migrations, and API details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,14 @@ Configure these in **Cloud Agents → Secrets** (one download method is enough):
 | `FOUNDRY_USER` | Display name on `/join` for Playwright E2E |
 | `FOUNDRY_PASSWORD` | Optional password for that **game** user on `/join` |
 
-Start server after secrets are set: `/home/ubuntu/start-foundry.sh`
+Start server after secrets are set:
+
+```bash
+bash scripts/cloud-foundry.sh start   # preferred: copies system, creates sla-test-world, auto-launches
+npm run test:env                      # build + unit + E2E when Foundry is up
+```
+
+Foundry v14 does not reliably detect **symlinked** systems — `cloud-foundry.sh` **rsyncs** `/workspace` into `Data/systems/sla-industries`. The test world id is `sla-test-world` (`FOUNDRY_WORLD` / `FOUNDRY_WORLD_ID`). Run `node scripts/ensure-foundry-user.mjs` if `FOUNDRY_USER` is not on the join page yet.
 
 If cloud secrets are not configured, export the same variables in your shell (or pass them only for that command) before running the script — Foundry cannot be downloaded without them.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,21 @@ There is **no** `npm run lint` script or ESLint config; format with Prettier loc
 
 ### Foundry (required for E2E and real UI testing)
 
+#### Cursor Cloud secrets
+
+Configure these in the agent environment (one download method is enough):
+
+| Secret | Purpose |
+|--------|---------|
+| `FOUNDRY_RELEASE_URL` | Timed **Node.js** download URL from [foundryvtt.com/me/licenses](https://foundryvtt.com/me/licenses) (Operating System → Node.js → Timed URL) |
+| `FOUNDRY_LICENSE_KEY` | License key `AAAA-BBBB-...` (optional if using account login; Docker can auto-fetch) |
+| `FOUNDRY_USERNAME` | foundryvtt.com email (alternative to `FOUNDRY_RELEASE_URL`) |
+| `FOUNDRY_ACCOUNT_PASSWORD` | foundryvtt.com password (only with `FOUNDRY_USERNAME`; do not confuse with join-page password) |
+| `FOUNDRY_USER` | Display name on `/join` for Playwright E2E |
+| `FOUNDRY_PASSWORD` | Optional password for that **game** user on `/join` |
+
+Start server after secrets are set: `/home/ubuntu/start-foundry.sh`
+
 1. **Install Foundry VTT v14** (verified against **14.360** per `system.json`). This cloud VM uses Docker (`ghcr.io/felddy/foundryvtt:14`) when credentials are provided.
 2. **Link this repo** into Foundry data as `Data/systems/sla-industries` (folder name must match `system.json` `id`). On this VM the symlink is already at `/home/ubuntu/foundry-data/Data/systems/sla-industries` → `/workspace`.
 3. **Create a world** using game system **SLA Industries 2nd Edition** and at least one user for `/join`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository is a **Foundry VTT v14 game system** (SLA Industries 2nd Edition). There is no standalone web app or `npm run dev` server — Foundry is the runtime.
+
+### What works without Foundry
+
+| Task | Command |
+|------|---------|
+| Install JS deps | `npm install` |
+| Compile SCSS | `npm run build` (or `npm run watch` while editing styles) |
+| Unit tests | `npm run test:unit` (Node built-in test runner; no Foundry required) |
+
+There is **no** `npm run lint` script or ESLint config; format with Prettier locally if needed (`DEVELOPER.md`).
+
+### Foundry (required for E2E and real UI testing)
+
+1. **Install Foundry VTT v14** (verified against **14.360** per `system.json`). This cloud VM uses Docker (`ghcr.io/felddy/foundryvtt:14`) when credentials are provided.
+2. **Link this repo** into Foundry data as `Data/systems/sla-industries` (folder name must match `system.json` `id`). On this VM the symlink is already at `/home/ubuntu/foundry-data/Data/systems/sla-industries` → `/workspace`.
+3. **Create a world** using game system **SLA Industries 2nd Edition** and at least one user for `/join`.
+4. **Environment variables for Playwright** (see `playwright.config.js`):
+   - `FOUNDRY_URL` — default `http://127.0.0.1:30000`
+   - `FOUNDRY_USER` — display name on the join page (required for authenticated E2E)
+   - `FOUNDRY_PASSWORD` — if the user has a password
+5. GM-only operator tests (`npm run test:e2e:operators`) need `FOUNDRY_USER` to be a Gamemaster.
+
+Example Docker start (after setting secrets in the environment):
+
+```bash
+docker run -d --name foundry \
+  --hostname foundry-server \
+  -p 30000:30000 \
+  -v /home/ubuntu/foundry-data:/data \
+  -e FOUNDRY_RELEASE_URL \
+  -e FOUNDRY_LICENSE_KEY \
+  ghcr.io/felddy/foundryvtt:14
+```
+
+Use a **stable `--hostname`**; Foundry binds licenses to the container host.
+
+### E2E commands
+
+```bash
+npm run test:e2e:install   # Chromium (once per fresh VM)
+npm run test:e2e           # smoke + all specs
+npm run test:e2e:regression
+npm run test:e2e:operators
+```
+
+### Gotchas
+
+- Playwright does **not** start Foundry; the server must already be listening on `FOUNDRY_URL`.
+- After SCSS changes, run `npm run build` — hot reload is via Foundry refresh (F5), not Vite.
+- Foundry toast notifications can block Playwright clicks; tests use `dismissFoundryNotifications()` in `tests/e2e/fixtures.js`.
+
+See `DEVELOPER.md` for architecture, migrations, and API details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ This repository is a **Foundry VTT v14 game system** (SLA Industries 2nd Edition
 
 ### What works without Foundry
 
+Cloud agents can develop and verify this repo **without** Foundry license secrets using the commands below. E2E and in-browser testing stay optional until you run your own Foundry instance locally or add credentials.
+
 | Task | Command |
 |------|---------|
 | Install JS deps | `npm install` |
@@ -38,6 +40,8 @@ docker run -d --name foundry \
 ```
 
 Use a **stable `--hostname`**; Foundry binds licenses to the container host.
+
+On this cloud VM, run Docker with `sudo` unless your user is in the `docker` group (`sudo usermod -aG docker $USER`, then start a new shell).
 
 ### E2E commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ Configure these in the agent environment (one download method is enough):
 
 Start server after secrets are set: `/home/ubuntu/start-foundry.sh`
 
+If cloud secrets are not configured, export the same variables in your shell (or pass them only for that command) before running the script — Foundry cannot be downloaded without them.
+
 1. **Install Foundry VTT v14** (verified against **14.360** per `system.json`). This cloud VM uses Docker (`ghcr.io/felddy/foundryvtt:14`) when credentials are provided.
 2. **Link this repo** into Foundry data as `Data/systems/sla-industries` (folder name must match `system.json` `id`). On this VM the symlink is already at `/home/ubuntu/foundry-data/Data/systems/sla-industries` → `/workspace`.
 3. **Create a world** using game system **SLA Industries 2nd Edition** and at least one user for `/join`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.5.1] - 2026-06-05
+
+### Added
+
+* **Cursor Cloud development environment:** `.cursor/environment.json`, `AGENTS.md`, and scripts to prepare/start Foundry VTT for Playwright E2E (`scripts/cloud-foundry.sh`, `scripts/ensure-foundry-user.mjs`, `scripts/test-environment.sh`). New npm scripts: `test:env`, `foundry:start`, `foundry:status`.
+* **Foundry bootstrap helpers:** `scripts/foundry-bootstrap.mjs` for first-time license/world setup; `ensure-foundry-user.mjs` creates the `FOUNDRY_USER` join account when missing.
+
+### Changed
+
+* **Playwright E2E:** Default viewport set to 1920×1080 to satisfy Foundry’s minimum resolution in headless runs.
+* **`.gitignore`:** Track `.cursor/environment.json` while keeping other `.cursor/*` ignored.
+* Updated system and package metadata version to `2.5.1`, including the release `download` URL in `system.json`.
+
 ## [2.5.0] - 2026-04-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sla-industries",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "CSS compiler for the SLA Industries system",
   "scripts": {
     "build": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:install": "playwright install chromium",
     "test:env": "bash scripts/test-environment.sh",
+    "foundry:start": "bash scripts/cloud-foundry.sh start",
+    "foundry:status": "bash scripts/cloud-foundry.sh status",
     "test": "npm run test:unit && npm run test:e2e"
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:install": "playwright install chromium",
+    "test:env": "bash scripts/test-environment.sh",
     "test": "npm run test:unit && npm run test:e2e"
   },
   "browserslist": [

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -21,6 +21,7 @@ module.exports = defineConfig({
     reporter: [["list"], ["html", { open: "never" }]],
     use: {
         baseURL: process.env.FOUNDRY_URL || "http://127.0.0.1:30000",
+        viewport: { width: 1920, height: 1080 },
         trace: "on-first-retry",
         screenshot: "only-on-failure",
         video: "retain-on-failure"

--- a/scripts/cloud-foundry.sh
+++ b/scripts/cloud-foundry.sh
@@ -6,17 +6,53 @@ set -euo pipefail
 DATA_DIR="${FOUNDRY_DATA_DIR:-/home/ubuntu/foundry-data}"
 IMAGE="${FOUNDRY_IMAGE:-ghcr.io/felddy/foundryvtt:14}"
 PORT="${FOUNDRY_PORT:-30000}"
+WORLD_ID="${FOUNDRY_WORLD_ID:-sla-test-world}"
 START_SCRIPT="${FOUNDRY_START_SCRIPT:-/home/ubuntu/start-foundry.sh}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 cmd="${1:-status}"
 
+sync_system_install() {
+  local dest="$DATA_DIR/Data/systems/sla-industries"
+  if [[ -L "$dest" ]] || [[ ! -f "$dest/system.json" ]]; then
+    echo "Installing sla-industries system (copy; Foundry v14 does not load symlinked systems reliably)..."
+    rm -rf "$dest"
+    mkdir -p "$DATA_DIR/Data/systems"
+    rsync -a --exclude node_modules --exclude .git "$ROOT/" "$dest/"
+  fi
+}
+
+ensure_world_json() {
+  local world_dir="$DATA_DIR/Data/worlds/$WORLD_ID"
+  if [[ -f "$world_dir/world.json" ]]; then
+    return 0
+  fi
+  echo "Creating test world $WORLD_ID..."
+  mkdir -p "$world_dir"
+  cat >"$world_dir/world.json" <<EOF
+{
+  "id": "$WORLD_ID",
+  "title": "SLA Test World",
+  "description": "Cloud agent E2E world for SLA Industries",
+  "system": "sla-industries",
+  "coreVersion": "14.363",
+  "systemVersion": "2.5.0"
+}
+EOF
+}
+
+clear_stale_lock() {
+  sudo rm -rf "$DATA_DIR/Config/options.json.lock" 2>/dev/null || true
+}
+
 prepare() {
-  mkdir -p "$DATA_DIR/Data/systems" "$DATA_DIR/container_cache"
-  ln -sfn /workspace "$DATA_DIR/Data/systems/sla-industries"
+  mkdir -p "$DATA_DIR/Data/systems" "$DATA_DIR/Data/worlds" "$DATA_DIR/container_cache"
+  sync_system_install
+  ensure_world_json
   if command -v docker >/dev/null 2>&1; then
     sudo docker pull "$IMAGE" >/dev/null 2>&1 || sudo docker pull "$IMAGE"
   fi
-  echo "Foundry data ready at $DATA_DIR (system → /workspace)"
+  echo "Foundry data ready at $DATA_DIR"
 }
 
 has_download_creds() {
@@ -28,48 +64,62 @@ has_cache_zip() {
 }
 
 foundry_listening() {
-  curl -sf --max-time 2 "http://127.0.0.1:${PORT}/" >/dev/null 2>&1
+  curl -sf --max-time 2 "http://127.0.0.1:${PORT}/join" 2>/dev/null | rg -q "Join Game Session" || \
+    curl -sf --max-time 2 "http://127.0.0.1:${PORT}/" >/dev/null 2>&1
+}
+
+bootstrap_users() {
+  if [[ -z "${FOUNDRY_USER:-}" ]]; then
+    return 0
+  fi
+  if ! foundry_listening; then
+    return 0
+  fi
+  node "$ROOT/scripts/ensure-foundry-user.mjs" || true
 }
 
 start() {
   prepare
+  clear_stale_lock
+
   if foundry_listening; then
     echo "Foundry already listening on http://127.0.0.1:${PORT}"
+    bootstrap_users
     return 0
   fi
 
-  if has_download_creds && [[ -x "$START_SCRIPT" ]]; then
-    echo "Starting Foundry via download credentials..."
-    "$START_SCRIPT"
-    return $?
-  fi
+  export FOUNDRY_WORLD="${FOUNDRY_WORLD:-$WORLD_ID}"
 
-  if has_cache_zip; then
-    echo "Starting Foundry from container cache (no release URL)..."
+  if has_download_creds && [[ -x "$START_SCRIPT" ]]; then
+    echo "Starting Foundry via credentials (world=$FOUNDRY_WORLD)..."
+    "$START_SCRIPT"
+  elif has_cache_zip; then
+    echo "Starting Foundry from container cache (world=$FOUNDRY_WORLD)..."
     sudo docker rm -f foundry 2>/dev/null || true
-    ENV_ARGS=(-e "FOUNDRY_TELEMETRY=false")
+    ENV_ARGS=(-e "FOUNDRY_TELEMETRY=false" -e "FOUNDRY_WORLD=${FOUNDRY_WORLD}")
     [[ -n "${FOUNDRY_LICENSE_KEY:-}" ]] && ENV_ARGS+=(-e "FOUNDRY_LICENSE_KEY=${FOUNDRY_LICENSE_KEY}")
-    [[ -n "${FOUNDRY_ADMIN_KEY:-}" ]] && ENV_ARGS+=(-e "FOUNDRY_ADMIN_KEY=${FOUNDRY_ADMIN_KEY}")
+    [[ -n "${FOUNDRY_RELEASE_URL:-}" ]] && ENV_ARGS+=(-e "FOUNDRY_RELEASE_URL=${FOUNDRY_RELEASE_URL}")
     sudo docker run -d --name foundry \
       --hostname "${FOUNDRY_DOCKER_HOSTNAME:-foundry-server}" \
       -p "${PORT}:30000" \
       -v "${DATA_DIR}:/data" \
       "${ENV_ARGS[@]}" \
       "$IMAGE"
-    for _ in $(seq 1 120); do
-      if foundry_listening; then
-        echo "Foundry is up at http://127.0.0.1:${PORT}"
-        return 0
-      fi
-      sleep 2
-    done
-    echo "Foundry cache start timed out. sudo docker logs foundry" >&2
-    return 1
+  else
+    echo "Foundry not started: add Cloud Agents secrets (see AGENTS.md)."
+    return 0
   fi
 
-  echo "Foundry not started: add secrets in Cursor → Cloud Agents → Secrets (see AGENTS.md)."
-  echo "  Need FOUNDRY_RELEASE_URL or FOUNDRY_USERNAME + FOUNDRY_ACCOUNT_PASSWORD, and usually FOUNDRY_LICENSE_KEY."
-  return 0
+  for _ in $(seq 1 120); do
+    if foundry_listening; then
+      echo "Foundry is up at http://127.0.0.1:${PORT}"
+      bootstrap_users
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Foundry start timed out. sudo docker logs foundry" >&2
+  return 1
 }
 
 status() {
@@ -85,5 +135,6 @@ case "$cmd" in
   prepare) prepare ;;
   start) start ;;
   status) status ;;
-  *) echo "Usage: $0 {prepare|start|status}" >&2; exit 1 ;;
+  bootstrap) prepare; bootstrap_users ;;
+  *) echo "Usage: $0 {prepare|start|status|bootstrap}" >&2; exit 1 ;;
 esac

--- a/scripts/cloud-foundry.sh
+++ b/scripts/cloud-foundry.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Cursor Cloud: prepare/start Foundry for SLA Industries E2E.
+# Credentials come from Cloud Agents → Secrets (workspace), not from the repo.
+set -euo pipefail
+
+DATA_DIR="${FOUNDRY_DATA_DIR:-/home/ubuntu/foundry-data}"
+IMAGE="${FOUNDRY_IMAGE:-ghcr.io/felddy/foundryvtt:14}"
+PORT="${FOUNDRY_PORT:-30000}"
+START_SCRIPT="${FOUNDRY_START_SCRIPT:-/home/ubuntu/start-foundry.sh}"
+
+cmd="${1:-status}"
+
+prepare() {
+  mkdir -p "$DATA_DIR/Data/systems" "$DATA_DIR/container_cache"
+  ln -sfn /workspace "$DATA_DIR/Data/systems/sla-industries"
+  if command -v docker >/dev/null 2>&1; then
+    sudo docker pull "$IMAGE" >/dev/null 2>&1 || sudo docker pull "$IMAGE"
+  fi
+  echo "Foundry data ready at $DATA_DIR (system → /workspace)"
+}
+
+has_download_creds() {
+  [[ -n "${FOUNDRY_RELEASE_URL:-}" || -n "${FOUNDRY_USERNAME:-}" ]]
+}
+
+has_cache_zip() {
+  compgen -G "$DATA_DIR/container_cache/foundryvtt-"*.zip >/dev/null 2>&1
+}
+
+foundry_listening() {
+  curl -sf --max-time 2 "http://127.0.0.1:${PORT}/" >/dev/null 2>&1
+}
+
+start() {
+  prepare
+  if foundry_listening; then
+    echo "Foundry already listening on http://127.0.0.1:${PORT}"
+    return 0
+  fi
+
+  if has_download_creds && [[ -x "$START_SCRIPT" ]]; then
+    echo "Starting Foundry via download credentials..."
+    "$START_SCRIPT"
+    return $?
+  fi
+
+  if has_cache_zip; then
+    echo "Starting Foundry from container cache (no release URL)..."
+    sudo docker rm -f foundry 2>/dev/null || true
+    ENV_ARGS=(-e "FOUNDRY_TELEMETRY=false")
+    [[ -n "${FOUNDRY_LICENSE_KEY:-}" ]] && ENV_ARGS+=(-e "FOUNDRY_LICENSE_KEY=${FOUNDRY_LICENSE_KEY}")
+    [[ -n "${FOUNDRY_ADMIN_KEY:-}" ]] && ENV_ARGS+=(-e "FOUNDRY_ADMIN_KEY=${FOUNDRY_ADMIN_KEY}")
+    sudo docker run -d --name foundry \
+      --hostname "${FOUNDRY_DOCKER_HOSTNAME:-foundry-server}" \
+      -p "${PORT}:30000" \
+      -v "${DATA_DIR}:/data" \
+      "${ENV_ARGS[@]}" \
+      "$IMAGE"
+    for _ in $(seq 1 120); do
+      if foundry_listening; then
+        echo "Foundry is up at http://127.0.0.1:${PORT}"
+        return 0
+      fi
+      sleep 2
+    done
+    echo "Foundry cache start timed out. sudo docker logs foundry" >&2
+    return 1
+  fi
+
+  echo "Foundry not started: add secrets in Cursor → Cloud Agents → Secrets (see AGENTS.md)."
+  echo "  Need FOUNDRY_RELEASE_URL or FOUNDRY_USERNAME + FOUNDRY_ACCOUNT_PASSWORD, and usually FOUNDRY_LICENSE_KEY."
+  return 0
+}
+
+status() {
+  if foundry_listening; then
+    echo "foundry:up http://127.0.0.1:${PORT}"
+    return 0
+  fi
+  echo "foundry:down"
+  return 1
+}
+
+case "$cmd" in
+  prepare) prepare ;;
+  start) start ;;
+  status) status ;;
+  *) echo "Usage: $0 {prepare|start|status}" >&2; exit 1 ;;
+esac

--- a/scripts/ensure-foundry-user.mjs
+++ b/scripts/ensure-foundry-user.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Ensure FOUNDRY_USER exists on the join page (creates GM user if missing).
+ * Uses Gamemaster (default, no password) when the world is already running.
+ */
+import { chromium } from "@playwright/test";
+
+const base = process.env.FOUNDRY_URL || "http://127.0.0.1:30000";
+const targetName = process.env.FOUNDRY_USER;
+const targetPassword = process.env.FOUNDRY_PASSWORD ?? "";
+
+if (!targetName) {
+    console.error("FOUNDRY_USER is required");
+    process.exit(1);
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+await page.setViewportSize({ width: 1920, height: 1080 });
+
+await page.goto(`${base}/join`, { waitUntil: "networkidle", timeout: 60_000 });
+
+const labels = await page.locator("select[name='userid'] option").allTextContents();
+if (labels.some((l) => l.trim() === targetName)) {
+    console.log(`User "${targetName}" already on join page.`);
+    await browser.close();
+    process.exit(0);
+}
+
+if (!labels.some((l) => l.trim() === "Gamemaster")) {
+    console.error("Gamemaster user not found; launch sla-test-world first.");
+    process.exit(1);
+}
+
+console.log(`Creating join user "${targetName}" via Gamemaster session...`);
+await page.locator("select[name='userid']").selectOption({ label: "Gamemaster" });
+await page.getByRole("textbox", { name: /password/i }).fill("");
+await page.getByRole("button", { name: /join game session/i }).click();
+await page.waitForURL(/\/game/, { timeout: 90_000 });
+
+await page.waitForFunction(() => globalThis.game?.ready === true, null, { timeout: 90_000 });
+
+const created = await page.evaluate(
+    async ({ name, password }) => {
+        const existing = game.users.find((u) => u.name === name);
+        if (existing) return { ok: true, existed: true };
+        const doc = await User.create({
+            name,
+            role: CONST.USER_ROLES.GAMEMASTER,
+            password: password || undefined
+        });
+        return { ok: Boolean(doc), id: doc?.id };
+    },
+    { name: targetName, password: targetPassword || null }
+);
+
+if (!created.ok) {
+    console.error("Failed to create user", created);
+    process.exit(1);
+}
+
+console.log(created.existed ? "User already existed in world data." : `Created user id=${created.id}`);
+
+await page.evaluate(async () => {
+    await game.shutDown();
+});
+await page.waitForURL(/\/join|\/setup/, { timeout: 60_000 }).catch(() => {});
+
+await browser.close();
+console.log("Done.");

--- a/scripts/foundry-bootstrap.mjs
+++ b/scripts/foundry-bootstrap.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+import { chromium } from '@playwright/test';
+
+const FOUNDRY_URL = 'http://127.0.0.1:30000';
+const LICENSE_KEY = process.env.FOUNDRY_LICENSE_KEY;
+const USER_NAME = process.env.FOUNDRY_USER;
+const PASSWORD = process.env.FOUNDRY_PASSWORD;
+
+async function bootstrap() {
+  console.log('Starting Foundry VTT first-time setup...');
+  
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    // Step 1: Handle license page
+    console.log('Step 1: Checking license page...');
+    await page.goto(`${FOUNDRY_URL}/license`, { waitUntil: 'networkidle', timeout: 30000 });
+    await page.screenshot({ path: '/tmp/license-page.png', fullPage: true });
+    console.log('  Screenshot saved to /tmp/license-page.png');
+    
+    // Check if we need to submit license key
+    const licenseInput = await page.locator('input[name="licenseKey"]').count();
+    if (licenseInput > 0) {
+      console.log('  Submitting license key...');
+      await page.fill('input[name="licenseKey"]', LICENSE_KEY);
+      await page.click('button[type="submit"]');
+      await page.waitForLoadState('networkidle');
+      console.log('  License key submitted');
+    } else {
+      console.log('  Checking for EULA agreement...');
+      // Look for EULA checkbox or agreement button
+      const eulaCheckbox = page.locator('input[name="eula"]');
+      const agreeButton = page.locator('button:has-text("agree"), button:has-text("Accept"), button:has-text("Continue")');
+      
+      if (await eulaCheckbox.count() > 0) {
+        console.log('  Checking EULA checkbox...');
+        await eulaCheckbox.check();
+      }
+      
+      if (await agreeButton.count() > 0) {
+        console.log('  Clicking agreement button...');
+        await agreeButton.first().click();
+        await page.waitForLoadState('networkidle');
+        console.log('  License accepted');
+      } else {
+        console.log('  License already accepted');
+      }
+    }
+
+    // Step 2: Setup page - create world and user
+    console.log('Step 2: Navigating to setup page...');
+    await page.goto(`${FOUNDRY_URL}/setup`, { waitUntil: 'networkidle', timeout: 30000 });
+    await page.screenshot({ path: '/tmp/setup-page.png', fullPage: true });
+    console.log('  Screenshot saved to /tmp/setup-page.png');
+    
+    // Wait a bit for the page to fully render
+    await page.waitForTimeout(2000);
+    
+    // Check if we need to create a world
+    console.log('  Checking for existing worlds...');
+    const worldsList = await page.locator('#worlds-list li.world, .world-entry').count();
+    
+    if (worldsList === 0) {
+      console.log('  Creating new world...');
+      // Try multiple selectors for the create button
+      const createSelectors = [
+        'button[data-action="createWorld"]',
+        'a[data-action="createWorld"]',
+        'button:has-text("Create World")',
+        '#worlds-list button.create-world',
+        '.worlds button.create'
+      ];
+      
+      let createClicked = false;
+      for (const selector of createSelectors) {
+        if (await page.locator(selector).count() > 0) {
+          console.log(`  Found create button: ${selector}`);
+          await page.locator(selector).first().click();
+          createClicked = true;
+          break;
+        }
+      }
+      
+      if (!createClicked) {
+        throw new Error('Could not find create world button');
+      }
+      
+      await page.waitForSelector('form#world-create, form.world-create, .window-content form', { timeout: 10000 });
+      
+      // Fill world creation form
+      await page.fill('input[name="title"]', 'SLA Industries Test World');
+      
+      // Wait for system dropdown to be populated
+      await page.waitForTimeout(1000);
+      await page.selectOption('select[name="system"]', 'sla-industries');
+      
+      await page.click('button[type="submit"]');
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(2000);
+      console.log('  World created');
+    } else {
+      console.log(`  Found ${worldsList} existing world(s)`);
+    }
+
+    // Create user if needed
+    console.log('  Checking for users...');
+    await page.goto(`${FOUNDRY_URL}/setup`, { waitUntil: 'networkidle', timeout: 30000 });
+    await page.waitForTimeout(1000);
+    
+    const usersList = await page.locator('#users-list li.user, .user-entry').count();
+    
+    if (usersList === 0) {
+      console.log('  Creating user...');
+      // Try multiple selectors for create user button
+      const createUserSelectors = [
+        'button[data-action="createUser"]',
+        'a[data-action="createUser"]',
+        'button:has-text("Create User")',
+        '#users-list button.create-user',
+        '.users button.create'
+      ];
+      
+      let createClicked = false;
+      for (const selector of createUserSelectors) {
+        if (await page.locator(selector).count() > 0) {
+          console.log(`  Found create user button: ${selector}`);
+          await page.locator(selector).first().click();
+          createClicked = true;
+          break;
+        }
+      }
+      
+      if (!createClicked) {
+        throw new Error('Could not find create user button');
+      }
+      
+      await page.waitForSelector('form#user-create, form.user-create, .window-content form', { timeout: 10000 });
+      
+      await page.fill('input[name="name"]', USER_NAME);
+      if (PASSWORD) {
+        await page.fill('input[name="password"]', PASSWORD);
+        await page.fill('input[name="passwordConfirm"]', PASSWORD);
+      }
+      // Try to set role to Gamemaster (value might be "4" or "GAMEMASTER")
+      const roleSelect = page.locator('select[name="role"]');
+      if (await roleSelect.count() > 0) {
+        await roleSelect.selectOption({ index: await roleSelect.locator('option').count() - 1 });
+      }
+      
+      await page.click('button[type="submit"]');
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(2000);
+      console.log('  User created');
+    } else {
+      console.log(`  Found ${usersList} existing user(s)`);
+    }
+
+    // Step 3: Launch the world
+    console.log('Step 3: Launching world...');
+    await page.goto(`${FOUNDRY_URL}/setup`, { waitUntil: 'networkidle', timeout: 30000 });
+    await page.waitForTimeout(1000);
+    await page.screenshot({ path: '/tmp/setup-before-launch.png', fullPage: true });
+    
+    // Find and click the launch button for the world
+    const launchSelectors = [
+      'li.world button[data-action="launchWorld"]',
+      'button[data-action="launchWorld"]',
+      'button.launch-world',
+      'button:has-text("Launch")'
+    ];
+    
+    let launched = false;
+    for (const selector of launchSelectors) {
+      if (await page.locator(selector).count() > 0) {
+        console.log(`  Found launch button: ${selector}`);
+        await page.locator(selector).first().click();
+        launched = true;
+        break;
+      }
+    }
+    
+    if (!launched) {
+      throw new Error('Could not find launch world button');
+    }
+    
+    console.log('  Waiting for world to launch...');
+    await page.waitForURL(/\/(game|join)/, { timeout: 60000 });
+    console.log('  World launched successfully');
+
+    // Verify /join is accessible
+    console.log('Step 4: Verifying /join endpoint...');
+    await page.goto(`${FOUNDRY_URL}/join`, { waitUntil: 'networkidle', timeout: 30000 });
+    const joinPage = await page.locator('body').isVisible();
+    if (joinPage) {
+      console.log('  /join is accessible');
+    }
+
+    console.log('\n✓ Foundry VTT setup completed successfully!');
+    await browser.close();
+    process.exit(0);
+
+  } catch (error) {
+    console.error('\n✗ Setup failed:', error.message);
+    await page.screenshot({ path: '/tmp/foundry-setup-error.png', fullPage: true });
+    console.error('Screenshot saved to /tmp/foundry-setup-error.png');
+    await browser.close();
+    process.exit(1);
+  }
+}
+
+bootstrap();

--- a/scripts/test-environment.sh
+++ b/scripts/test-environment.sh
@@ -10,6 +10,8 @@ echo "=== SLA Industries environment test ==="
 npm run build
 npm run test:unit
 
+bash scripts/cloud-foundry.sh start || true
+
 if bash scripts/cloud-foundry.sh status >/dev/null 2>&1; then
   echo "=== Foundry is up — running E2E ==="
   if [[ -z "${FOUNDRY_USER:-}" ]]; then

--- a/scripts/test-environment.sh
+++ b/scripts/test-environment.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Run the standard cloud environment verification suite.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "=== SLA Industries environment test ==="
+
+npm run build
+npm run test:unit
+
+if bash scripts/cloud-foundry.sh status >/dev/null 2>&1; then
+  echo "=== Foundry is up — running E2E ==="
+  if [[ -z "${FOUNDRY_USER:-}" ]]; then
+    echo "WARN: FOUNDRY_USER not set; authenticated E2E specs will skip."
+  fi
+  npm run test:e2e
+else
+  echo "=== Foundry not running — skipping E2E (unit + build passed) ==="
+  bash scripts/cloud-foundry.sh start || true
+  if bash scripts/cloud-foundry.sh status >/dev/null 2>&1; then
+    echo "Foundry came up after start; running E2E..."
+    npm run test:e2e
+  else
+    echo "E2E skipped. Configure Cloud Agents secrets or save a VM snapshot with Foundry installed."
+  fi
+fi
+
+echo "=== Environment test complete ==="

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "compatibility": {
     "minimum": "14",
     "verified": "14.360"
@@ -50,7 +50,7 @@
   ],
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.0/sla-industries.zip",
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.1/sla-industries.zip",
   "packs": [
     {
       "name": "skills",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Release 2.5.1

Patch release adding **developer/CI tooling** only — no game-system or world-migration changes (`CURRENT_MIGRATION_VERSION` remains `2.5.0`).

### Added
- Cursor Cloud environment (`.cursor/environment.json`, `AGENTS.md`, Foundry bootstrap scripts)
- `npm run test:env`, `foundry:start`, `foundry:status`

### Changed
- Playwright default viewport 1920×1080 for Foundry E2E
- Version bumped to **2.5.1** in `system.json`, `package.json`, and `CHANGELOG.md`

### After merge
GitHub Actions on `main` will create a **draft** GitHub Release `2.5.1` with `sla-industries.zip` and `system.json`. Publish the draft release to trigger the Foundry website manifest update workflow.

### Verification
- `npm run build` — OK
- `npm run test:unit` — 20/20 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f99664e6-4ac6-4f83-88e7-f3c417d86974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f99664e6-4ac6-4f83-88e7-f3c417d86974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

