### PR TITLE
Release packaging: dist/ build output (2.5.2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,32 +12,47 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Get Version                                   # Run the script that returns the version from `module.json`
-      shell: bash
-      id: get-version
-      run: echo "::set-output name=version::$(node ./.github/workflows/get-version.js)"
-    - run: git archive --format=zip --output=sla-industries.zip main
-    - name: Create Release                                # Create an additional release for this version
-      id: create_versioned_release
-      uses: ncipollo/release-action@v1
-      with:
-        allowUpdates: true # set to false if you do not want to allow updates on existing releases
-        name: Release ${{ steps.get-version.outputs.version }} # Use the version in the name
-        draft: true
-        prerelease: false
-        token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: './system.json,./sla-industries.zip'
-        tag: ${{ steps.get-version.outputs.version }} # Use the version as the tag
-    - name: Create Release
-      id: create_latest_release
-      uses: ncipollo/release-action@v1
-      if: endsWith(github.ref, 'master') # Only update the latest release when pushing to the master branch
-      with:
-        allowUpdates: true
-        name: Latest
-        draft: true
-        prerelease: false
-        token: ${{ secrets.GITHUB_TOKEN }}
-        artifacts: './system.json,./sla-industries.zip'
-        tag: latest
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Get Version
+        id: get-version
+        run: echo "version=$(node ./.github/workflows/get-version.js)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and package release zip
+        run: npm run package
+
+      - name: Copy manifest for release asset
+        run: cp dist/system.json system.json
+
+      - name: Create Release
+        id: create_versioned_release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          name: Release ${{ steps.get-version.outputs.version }}
+          draft: true
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "./system.json,./sla-industries.zip"
+          tag: ${{ steps.get-version.outputs.version }}
+
+      - name: Create Latest release
+        id: create_latest_release
+        uses: ncipollo/release-action@v1
+        if: endsWith(github.ref, 'master')
+        with:
+          allowUpdates: true
+          name: Latest
+          draft: true
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "./system.json,./sla-industries.zip"
+          tag: latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 node_modules/
 
+# Release build output (Foundry-installable tree)
+dist/
+.package-stage/
+sla-industries.zip
+
 # Playwright
 /playwright-report/
 /test-results/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ bash scripts/cloud-foundry.sh start   # preferred: copies system, creates sla-te
 npm run test:env                      # build + unit + E2E when Foundry is up
 ```
 
-Foundry v14 does not reliably detect **symlinked** systems — `cloud-foundry.sh` **rsyncs** `/workspace` into `Data/systems/sla-industries`. The test world id is `sla-test-world` (`FOUNDRY_WORLD` / `FOUNDRY_WORLD_ID`). Run `node scripts/ensure-foundry-user.mjs` if `FOUNDRY_USER` is not on the join page yet.
+Release builds use **`dist/`** (runtime files only). `npm run build` compiles SCSS and assembles `dist/`; `npm run package` creates `sla-industries.zip`. `cloud-foundry.sh` deploys **`dist/`** into Foundry data (not the full git tree). The test world id is `sla-test-world` (`FOUNDRY_WORLD` / `FOUNDRY_WORLD_ID`). Run `node scripts/ensure-foundry-user.mjs` if `FOUNDRY_USER` is not on the join page yet.
 
 If cloud secrets are not configured, export the same variables in your shell (or pass them only for that command) before running the script — Foundry cannot be downloaded without them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.5.2] - 2026-06-05
+
+### Added
+
+* **Release packaging:** `dist/` build output and `npm run package` produce `sla-industries.zip` containing only Foundry runtime files (aligned with `fvtt-cyberpunk-red-core-dev`). Scripts: `scripts/build-dist.mjs`, `scripts/package-release.sh`.
+
+### Changed
+
+* **CI:** GitHub Actions runs `npm run package` instead of `git archive`, so dev tooling (`tests/`, `src/scss/`, Playwright config, cloud scripts, etc.) is excluded from release artifacts.
+* **`npm run build`:** Now runs `build:css` then assembles `dist/`; use `build:css` alone for SCSS-only local iteration.
+* **Cloud Foundry deploy:** `cloud-foundry.sh` syncs `dist/` into Foundry data after `npm run build`.
+* Updated system and package metadata version to `2.5.2`, including the release `download` URL in `system.json`.
+
 ## [2.5.1] - 2026-06-05
 
 ### Added

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -60,7 +60,7 @@ sla-industries/
 - **Foundry VTT v14** (minimum 14, verified 14.360)
 - **Application V2** (`ApplicationV2` + `HandlebarsApplicationMixin`) for all sheets and dialogs.
 - **TypeDataModel** (`foundry.abstract.TypeDataModel`) for all actor and item data schemas.
-- **SCSS** compiled to `css/sla-industries.css` via `npm run build` (or `npm run watch`).
+- **SCSS** compiled to `css/sla-industries.css` via `npm run build:css` (or `npm run watch`). `npm run build` also assembles **`dist/`** (Foundry-installable runtime files). `npm run package` produces `sla-industries.zip` for releases.
 - **Node.js test runner** for unit tests; **Playwright** for end-to-end tests.
 
 ---
@@ -265,8 +265,10 @@ E2E tests require:
 ### SCSS compilation
 
 ```bash
-npm run build    # one-time compile
-npm run watch    # live recompile on file changes
+npm run build:css   # SCSS → css/ (local Foundry dev)
+npm run build       # css + dist/ (release tree)
+npm run package     # dist/ → sla-industries.zip
+npm run watch       # live SCSS recompile
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "sla-industries",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "CSS compiler for the SLA Industries system",
   "scripts": {
-    "build": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",
+    "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",
+    "build:dist": "node scripts/build-dist.mjs",
+    "build": "npm run build:css && npm run build:dist",
+    "package": "bash scripts/package-release.sh",
     "watch": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map --watch",
     "test:unit": "node --test tests/unit/inventory-stack.test.mjs tests/unit/system-manifest.test.mjs tests/unit/dice.test.mjs tests/unit/chat-wound-options.test.mjs tests/unit/ebb-mos.test.mjs",
     "test:e2e": "playwright test",

--- a/scripts/build-dist.mjs
+++ b/scripts/build-dist.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Assemble Foundry-installable system files into dist/ (runtime only).
+ * Mirrors the fvtt-cyberpunk-red-core-dev pattern: dev sources stay in-repo;
+ * releases zip dist/, not the full git tree.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const dist = path.join(root, "dist");
+
+/** @type {Array<{ from: string; to?: string; files?: string[] }>} */
+const COPY_SPECS = [
+    { from: "module", to: "module" },
+    { from: "templates", to: "templates" },
+    { from: "lang", to: "lang" },
+    { from: "assets", to: "assets" },
+    { from: "css", to: "css" },
+    { from: "packs", to: "packs", files: ["disciplines.db", "quick-start-gear.db", "skills.db", "species.db", "traits.db", "vehicles.db"] },
+    { from: "scripts", to: "scripts", files: ["migrate_stat_damage.js"] },
+    { from: "system.json", to: "system.json" },
+    { from: "LICENSE.txt", to: "LICENSE.txt" }
+];
+
+function rmrf(dir) {
+    fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function copyFile(src, dest) {
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+}
+
+function copyDir(srcDir, destDir) {
+    fs.cpSync(srcDir, destDir, { recursive: true });
+}
+
+function assembleDist() {
+    rmrf(dist);
+    fs.mkdirSync(dist, { recursive: true });
+
+    for (const spec of COPY_SPECS) {
+        const src = path.join(root, spec.from);
+        const dest = path.join(dist, spec.to ?? spec.from);
+
+        if (spec.files) {
+            fs.mkdirSync(dest, { recursive: true });
+            for (const name of spec.files) {
+                copyFile(path.join(src, name), path.join(dest, name));
+            }
+            continue;
+        }
+
+        if (fs.statSync(src).isDirectory()) {
+            copyDir(src, dest);
+        } else {
+            copyFile(src, dest);
+        }
+    }
+}
+
+const cssOut = path.join(root, "css", "sla-industries.css");
+if (!fs.existsSync(cssOut)) {
+    console.error("Missing css/sla-industries.css — run npm run build:css first.");
+    process.exit(1);
+}
+
+assembleDist();
+console.log(`Built Foundry system package → ${dist}`);

--- a/scripts/cloud-foundry.sh
+++ b/scripts/cloud-foundry.sh
@@ -14,12 +14,11 @@ cmd="${1:-status}"
 
 sync_system_install() {
   local dest="$DATA_DIR/Data/systems/sla-industries"
-  if [[ -L "$dest" ]] || [[ ! -f "$dest/system.json" ]]; then
-    echo "Installing sla-industries system (copy; Foundry v14 does not load symlinked systems reliably)..."
-    rm -rf "$dest"
-    mkdir -p "$DATA_DIR/Data/systems"
-    rsync -a --exclude node_modules --exclude .git "$ROOT/" "$dest/"
-  fi
+  echo "Building dist/ and installing sla-industries into Foundry data..."
+  npm run build --prefix "$ROOT" >/dev/null
+  rm -rf "$dest"
+  mkdir -p "$DATA_DIR/Data/systems"
+  rsync -a "$ROOT/dist/" "$dest/"
 }
 
 ensure_world_json() {

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Build dist/ and create sla-industries.zip for Foundry installation.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+SYSTEM_ID="sla-industries"
+VERSION="$(node -p "require('./system.json').version")"
+STAGE="${ROOT}/.package-stage"
+ZIP="${ROOT}/${SYSTEM_ID}.zip"
+
+npm run build
+
+rm -rf "$STAGE" "$ZIP"
+mkdir -p "$STAGE"
+cp -a dist/. "$STAGE/${SYSTEM_ID}/"
+
+(
+  cd "$STAGE"
+  zip -qr "$ZIP" "$SYSTEM_ID"
+)
+
+rm -rf "$STAGE"
+echo "Created ${ZIP} (v${VERSION})"

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "compatibility": {
     "minimum": "14",
     "verified": "14.360"
@@ -50,7 +50,7 @@
   ],
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.1/sla-industries.zip",
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.2/sla-industries.zip",
   "packs": [
     {
       "name": "skills",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns release packaging with [fvtt-cyberpunk-red-core-dev](https://github.com/VacantFanatic/fvtt-cyberpunk-red-core-dev): **dev sources stay in the repo**, **`dist/` holds only Foundry runtime files**, and **`sla-industries.zip` is built from `dist/`** — not `git archive` of the full tree.

## Changes

### Build & package
- `scripts/build-dist.mjs` — assembles `dist/` from `module/`, `templates/`, `packs/*.db`, `css/`, `lang/`, `assets/`, `system.json`, `LICENSE.txt`, and runtime `scripts/migrate_stat_damage.js`
- `scripts/package-release.sh` — `npm run package` → `sla-industries.zip` with `sla-industries/` root folder
- `npm run build` = `build:css` + `build:dist`; `npm run build:css` for SCSS-only local dev

### CI
- `.github/workflows/main.yml` runs `npm ci`, `npm run package`, uploads `system.json` + zip (draft release)

### Excluded from zip (examples)
`tests/`, `src/scss/`, `package.json`, Playwright config, cloud/CI scripts, docs, `.github/`, etc.

### Version
**2.5.2** — `system.json`, `package.json`, `CHANGELOG.md`

## Verification
- `npm run package` — zip contains only runtime paths
- `npm run test:unit` — 20/20 passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f99664e6-4ac6-4f83-88e7-f3c417d86974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f99664e6-4ac6-4f83-88e7-f3c417d86974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

