### PR TITLE
Release packaging hardening (2.5.3)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify package.json and system.json versions match
+        run: node scripts/validate-dist.mjs --sync-only
+
+      - name: Run unit tests
+        run: npm run test:unit
+
       - name: Get Version
         id: get-version
         run: echo "version=$(node ./.github/workflows/get-version.js)" >> "$GITHUB_OUTPUT"
 
       - name: Build and package release zip
         run: npm run package
+
+      - name: Validate dist and zip artifacts
+        run: node scripts/validate-dist.mjs --zip
 
       - name: Copy manifest for release asset
         run: cp dist/system.json system.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.5.3] - 2026-06-05
+
+### Added
+
+* **Packaging validation:** `scripts/validate-dist.mjs` checks `dist/` and `sla-industries.zip` against `system.json` paths; `npm run validate:dist` / `validate:package`. Unit tests in `tests/unit/build-dist.test.mjs`.
+
+### Changed
+
+* **Compendium copy list** is derived from `system.json` `packs[].path` instead of a hardcoded array in `build-dist.mjs`.
+* **CI:** Runs version sync check, unit tests, `npm run package`, and `validate-dist.mjs --zip` before creating draft releases.
+* **`cloud-foundry.sh`:** Surfaces `npm run build` failures; test world `systemVersion` follows `system.json`.
+* Updated system and package metadata version to `2.5.3`, including the release `download` URL in `system.json`.
+
 ## [2.5.2] - 2026-06-05
 
 ### Added

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -268,6 +268,8 @@ E2E tests require:
 npm run build:css   # SCSS → css/ (local Foundry dev)
 npm run build       # css + dist/ (release tree)
 npm run package     # dist/ → sla-industries.zip
+npm run validate:dist    # assert dist/ matches system.json
+npm run validate:package # also validate zip layout
 npm run watch       # live SCSS recompile
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "sla-industries",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "CSS compiler for the SLA Industries system",
   "scripts": {
     "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",
     "build:dist": "node scripts/build-dist.mjs",
     "build": "npm run build:css && npm run build:dist",
     "package": "bash scripts/package-release.sh",
+    "validate:dist": "node scripts/validate-dist.mjs",
+    "validate:package": "node scripts/validate-dist.mjs --zip",
     "watch": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map --watch",
-    "test:unit": "node --test tests/unit/inventory-stack.test.mjs tests/unit/system-manifest.test.mjs tests/unit/dice.test.mjs tests/unit/chat-wound-options.test.mjs tests/unit/ebb-mos.test.mjs",
+    "test:unit": "node --test tests/unit/inventory-stack.test.mjs tests/unit/system-manifest.test.mjs tests/unit/dice.test.mjs tests/unit/chat-wound-options.test.mjs tests/unit/ebb-mos.test.mjs tests/unit/build-dist.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:regression": "playwright test tests/e2e/regression-sla.spec.js",
     "test:e2e:operators": "playwright test tests/e2e/regression-operators.spec.js",

--- a/scripts/build-dist.mjs
+++ b/scripts/build-dist.mjs
@@ -1,70 +1,104 @@
 #!/usr/bin/env node
 /**
  * Assemble Foundry-installable system files into dist/ (runtime only).
- * Mirrors the fvtt-cyberpunk-red-core-dev pattern: dev sources stay in-repo;
- * releases zip dist/, not the full git tree.
  */
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { loadManifest } from "./validate-dist.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const dist = path.join(root, "dist");
 
-/** @type {Array<{ from: string; to?: string; files?: string[] }>} */
-const COPY_SPECS = [
+/** Runtime scripts imported outside module/ (see module/migration.mjs). */
+const RUNTIME_SCRIPTS = ["migrate_stat_damage.js"];
+
+/** @type {Array<{ from: string; to?: string }>} */
+const STATIC_COPY_DIRS = [
     { from: "module", to: "module" },
     { from: "templates", to: "templates" },
     { from: "lang", to: "lang" },
     { from: "assets", to: "assets" },
-    { from: "css", to: "css" },
-    { from: "packs", to: "packs", files: ["disciplines.db", "quick-start-gear.db", "skills.db", "species.db", "traits.db", "vehicles.db"] },
-    { from: "scripts", to: "scripts", files: ["migrate_stat_damage.js"] },
-    { from: "system.json", to: "system.json" },
-    { from: "LICENSE.txt", to: "LICENSE.txt" }
+    { from: "css", to: "css" }
 ];
 
-function rmrf(dir) {
-    fs.rmSync(dir, { recursive: true, force: true });
+/**
+ * @param {string} src
+ * @param {string} label
+ */
+function requirePath(src, label) {
+    if (!fs.existsSync(src)) {
+        console.error(`Missing ${label}: ${path.relative(root, src)}`);
+        process.exit(1);
+    }
 }
 
-function copyFile(src, dest) {
+/**
+ * @param {string} src
+ * @param {string} dest
+ * @param {string} label
+ */
+function copyFile(src, dest, label) {
+    requirePath(src, label);
     fs.mkdirSync(path.dirname(dest), { recursive: true });
     fs.copyFileSync(src, dest);
 }
 
-function copyDir(srcDir, destDir) {
+/**
+ * @param {string} srcDir
+ * @param {string} destDir
+ * @param {string} label
+ */
+function copyDir(srcDir, destDir, label) {
+    requirePath(srcDir, label);
     fs.cpSync(srcDir, destDir, { recursive: true });
 }
 
+/**
+ * @param {import('./validate-dist.mjs').loadManifest extends (...args: any) => infer R ? R : never} manifest
+ * @returns {string[]}
+ */
+function packFileNames(manifest) {
+    const names = (manifest.packs ?? []).map((pack) => path.basename(String(pack.path)));
+    if (!names.length) {
+        console.error("system.json defines no compendium packs to copy.");
+        process.exit(1);
+    }
+    return names;
+}
+
 function assembleDist() {
-    rmrf(dist);
+    const manifest = loadManifest(root);
+    fs.rmSync(dist, { recursive: true, force: true });
     fs.mkdirSync(dist, { recursive: true });
 
-    for (const spec of COPY_SPECS) {
-        const src = path.join(root, spec.from);
-        const dest = path.join(dist, spec.to ?? spec.from);
-
-        if (spec.files) {
-            fs.mkdirSync(dest, { recursive: true });
-            for (const name of spec.files) {
-                copyFile(path.join(src, name), path.join(dest, name));
-            }
-            continue;
-        }
-
-        if (fs.statSync(src).isDirectory()) {
-            copyDir(src, dest);
-        } else {
-            copyFile(src, dest);
-        }
+    for (const spec of STATIC_COPY_DIRS) {
+        copyDir(
+            path.join(root, spec.from),
+            path.join(dist, spec.to ?? spec.from),
+            `${spec.from}/ directory`
+        );
     }
+
+    const packsSrc = path.join(root, "packs");
+    const packsDest = path.join(dist, "packs");
+    fs.mkdirSync(packsDest, { recursive: true });
+    for (const name of packFileNames(manifest)) {
+        copyFile(path.join(packsSrc, name), path.join(packsDest, name), `packs/${name}`);
+    }
+
+    const scriptsDest = path.join(dist, "scripts");
+    fs.mkdirSync(scriptsDest, { recursive: true });
+    for (const name of RUNTIME_SCRIPTS) {
+        copyFile(path.join(root, "scripts", name), path.join(scriptsDest, name), `scripts/${name}`);
+    }
+
+    copyFile(path.join(root, "system.json"), path.join(dist, "system.json"), "system.json");
+    copyFile(path.join(root, "LICENSE.txt"), path.join(dist, "LICENSE.txt"), "LICENSE.txt");
 }
 
 const cssOut = path.join(root, "css", "sla-industries.css");
-if (!fs.existsSync(cssOut)) {
-    console.error("Missing css/sla-industries.css — run npm run build:css first.");
-    process.exit(1);
-}
+requirePath(cssOut, "css/sla-industries.css (run npm run build:css first)");
 
 assembleDist();
 console.log(`Built Foundry system package → ${dist}`);

--- a/scripts/cloud-foundry.sh
+++ b/scripts/cloud-foundry.sh
@@ -15,7 +15,14 @@ cmd="${1:-status}"
 sync_system_install() {
   local dest="$DATA_DIR/Data/systems/sla-industries"
   echo "Building dist/ and installing sla-industries into Foundry data..."
-  npm run build --prefix "$ROOT" >/dev/null
+  if ! npm run build --prefix "$ROOT"; then
+    echo "npm run build failed — cannot deploy dist/ to Foundry." >&2
+    exit 1
+  fi
+  if [[ ! -f "$ROOT/dist/system.json" ]]; then
+    echo "dist/system.json missing after build." >&2
+    exit 1
+  fi
   rm -rf "$dest"
   mkdir -p "$DATA_DIR/Data/systems"
   rsync -a "$ROOT/dist/" "$dest/"
@@ -23,6 +30,8 @@ sync_system_install() {
 
 ensure_world_json() {
   local world_dir="$DATA_DIR/Data/worlds/$WORLD_ID"
+  local sys_version
+  sys_version="$(node -p "require('${ROOT}/system.json').version")"
   if [[ -f "$world_dir/world.json" ]]; then
     return 0
   fi
@@ -35,7 +44,7 @@ ensure_world_json() {
   "description": "Cloud agent E2E world for SLA Industries",
   "system": "sla-industries",
   "coreVersion": "14.363",
-  "systemVersion": "2.5.0"
+  "systemVersion": "${sys_version}"
 }
 EOF
 }

--- a/scripts/validate-dist.mjs
+++ b/scripts/validate-dist.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Validate dist/ (and optionally sla-industries.zip) against system.json manifest paths.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const distDir = path.join(root, "dist");
+const zipPath = path.join(root, "sla-industries.zip");
+const systemId = "sla-industries";
+
+/**
+ * @param {string} [rootDir]
+ */
+export function loadManifest(rootDir = root) {
+    const manifestPath = path.join(rootDir, "system.json");
+    if (!fs.existsSync(manifestPath)) {
+        throw new Error(`Missing system.json at ${manifestPath}`);
+    }
+    return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+}
+
+/**
+ * @param {Record<string, unknown>} manifest
+ * @returns {string[]}
+ */
+export function manifestAssetPaths(manifest) {
+    /** @type {string[]} */
+    const paths = [];
+
+    for (const entry of manifest.esmodules ?? []) {
+        paths.push(String(entry));
+    }
+    for (const entry of manifest.styles ?? []) {
+        paths.push(String(entry));
+    }
+    for (const entry of manifest.languages ?? []) {
+        if (entry?.path) paths.push(String(entry.path));
+    }
+    for (const pack of manifest.packs ?? []) {
+        if (pack?.path) paths.push(String(pack.path));
+    }
+
+    paths.push("system.json");
+    paths.push("scripts/migrate_stat_damage.js");
+
+    return [...new Set(paths)];
+}
+
+/**
+ * @param {string} baseDir
+ * @param {Record<string, unknown>} manifest
+ */
+export function validateDist(baseDir, manifest) {
+    if (!fs.existsSync(baseDir)) {
+        throw new Error(`dist directory not found: ${baseDir}`);
+    }
+
+    const distManifestPath = path.join(baseDir, "system.json");
+    if (!fs.existsSync(distManifestPath)) {
+        throw new Error("dist/system.json not found — run npm run build");
+    }
+
+    const distManifest = JSON.parse(fs.readFileSync(distManifestPath, "utf8"));
+    if (distManifest.id !== manifest.id) {
+        throw new Error(`dist system id mismatch: ${distManifest.id} !== ${manifest.id}`);
+    }
+    if (distManifest.version !== manifest.version) {
+        throw new Error(
+            `dist version mismatch: ${distManifest.version} !== ${manifest.version}`
+        );
+    }
+
+    const missing = [];
+    for (const rel of manifestAssetPaths(manifest)) {
+        const full = path.join(baseDir, rel);
+        if (!fs.existsSync(full)) {
+            missing.push(rel);
+        }
+    }
+
+    if (missing.length) {
+        throw new Error(`dist is missing manifest paths:\n  - ${missing.join("\n  - ")}`);
+    }
+
+    return { ok: true, pathCount: manifestAssetPaths(manifest).length };
+}
+
+/**
+ * @param {string} zipFile
+ */
+export function validateZip(zipFile = zipPath) {
+    if (!fs.existsSync(zipFile)) {
+        throw new Error(`zip not found: ${zipFile} — run npm run package`);
+    }
+
+    let listing;
+    try {
+        listing = execSync(`unzip -Z1 ${JSON.stringify(zipFile)}`, { encoding: "utf8" });
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`failed to list zip: ${message}`);
+    }
+
+    const entries = listing.trim().split("\n").filter(Boolean);
+    const prefix = `${systemId}/`;
+    const hasRootFolder = entries.some((e) => e.startsWith(prefix));
+    if (!hasRootFolder) {
+        throw new Error(`zip must contain top-level folder "${systemId}/"`);
+    }
+
+    const required = `${prefix}system.json`;
+    if (!entries.includes(required)) {
+        throw new Error(`zip missing ${required}`);
+    }
+
+    const devPatterns = [
+        /^sla-industries\/tests\//,
+        /^sla-industries\/src\//,
+        /^sla-industries\/package\.json$/,
+        /^sla-industries\/playwright\.config\.js$/,
+        /^sla-industries\/\.github\//
+    ];
+    const leaked = entries.filter((e) => devPatterns.some((re) => re.test(e)));
+    if (leaked.length) {
+        throw new Error(`zip contains dev artifacts:\n  - ${leaked.join("\n  - ")}`);
+    }
+
+    return { ok: true, entryCount: entries.length };
+}
+
+/**
+ * @param {string} rootDir
+ */
+export function assertVersionSync(rootDir = root) {
+    const pkg = JSON.parse(fs.readFileSync(path.join(rootDir, "package.json"), "utf8"));
+    const manifest = loadManifest(rootDir);
+    if (pkg.version !== manifest.version) {
+        throw new Error(
+            `version mismatch: package.json=${pkg.version}, system.json=${manifest.version}`
+        );
+    }
+}
+
+function runCli() {
+    const syncOnly = process.argv.includes("--sync-only");
+    const checkZip = process.argv.includes("--zip");
+
+    assertVersionSync(root);
+    if (syncOnly) {
+        console.log("version sync OK");
+        return;
+    }
+
+    const manifest = loadManifest(root);
+    const distResult = validateDist(distDir, manifest);
+    console.log(`dist OK (${distResult.pathCount} manifest paths)`);
+
+    if (checkZip) {
+        const zipResult = validateZip();
+        console.log(`zip OK (${zipResult.entryCount} entries)`);
+    }
+}
+
+const isMain =
+    process.argv[1] &&
+    path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+    runCli();
+}

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "compatibility": {
     "minimum": "14",
     "verified": "14.360"
@@ -50,7 +50,7 @@
   ],
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.2/sla-industries.zip",
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.3/sla-industries.zip",
   "packs": [
     {
       "name": "skills",

--- a/tests/unit/build-dist.test.mjs
+++ b/tests/unit/build-dist.test.mjs
@@ -1,0 +1,41 @@
+import { describe, test, before } from "node:test";
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+    assertVersionSync,
+    loadManifest,
+    validateDist,
+    validateZip
+} from "../../scripts/validate-dist.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const distDir = path.join(root, "dist");
+const zipPath = path.join(root, "sla-industries.zip");
+
+describe("release packaging", () => {
+    before(() => {
+        execSync("npm run build", { cwd: root, stdio: "pipe" });
+    });
+
+    test("package.json and system.json versions match", () => {
+        assert.doesNotThrow(() => assertVersionSync(root));
+    });
+
+    test("dist contains every manifest path", () => {
+        const manifest = loadManifest(root);
+        const result = validateDist(distDir, manifest);
+        assert.equal(result.ok, true);
+        assert.ok(result.pathCount >= 10);
+    });
+
+    test("npm run package produces a valid zip layout", () => {
+        execSync("npm run package", { cwd: root, stdio: "pipe" });
+        assert.ok(fs.existsSync(zipPath));
+        const result = validateZip(zipPath);
+        assert.equal(result.ok, true);
+        assert.ok(result.entryCount > 20);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements code-review follow-ups for dist/ release packaging.

## Changes

- **`scripts/validate-dist.mjs`** — version sync, manifest path checks on `dist/`, zip layout + dev-artifact leak detection (`--sync-only`, `--zip`)
- **`scripts/build-dist.mjs`** — compendium list derived from `system.json`; clearer missing-file errors
- **`tests/unit/build-dist.test.mjs`** — build, dist validation, and zip layout tests
- **CI** — version sync → unit tests → package → validate zip before draft release
- **`cloud-foundry.sh`** — fail on build errors; dynamic `systemVersion` in test world
- **`npm run validate:dist` / `validate:package`** scripts

## Version

**2.5.3**

## Verification

`npm run test:unit` — **23/23** passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f99664e6-4ac6-4f83-88e7-f3c417d86974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f99664e6-4ac6-4f83-88e7-f3c417d86974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

