### PR TITLE
Fix CI release automation for immutable releases

### DIFF
--- a/.github/workflows/foundry_manifest_update.yml
+++ b/.github/workflows/foundry_manifest_update.yml
@@ -17,13 +17,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: main
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Foundry Website Update
         id: foundry-website-update
-        uses: foundryvtt-dcc/foundry-package-release-action@main
-        with:
-          actionToken: ${{ secrets.GITHUB_TOKEN }}
-          manifestFileName: 'system.json'
-          foundryToken: ${{ secrets.FOUNDRY_PACKAGE_RELEASE_TOKEN }}
-          dryRun: false
+        env:
+          FOUNDRY_PACKAGE_RELEASE_TOKEN: ${{ secrets.FOUNDRY_PACKAGE_RELEASE_TOKEN }}
+          FOUNDRY_DRY_RUN: "false"
+        run: node scripts/update-foundry-release.mjs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
+          skipIfReleaseExists: true
           name: Release ${{ steps.get-version.outputs.version }}
           draft: true
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.5.4] - 2026-06-05
+
+### Fixed
+
+* **CI release publishing:** Main CI skips GitHub release creation when the versioned release already exists, avoiding immutable-release update failures on same-version main pushes.
+* **Foundry website update:** Replaced the third-party post-release action with a repo-local updater that uses the `system.json` package id (`sla-industries`) and the published release asset URL without forcing a `v` tag prefix.
+* Updated system and package metadata version to `2.5.4`, including the release `download` URL in `system.json`.
+
 ## [2.5.3] - 2026-06-05
 
 ### Added
@@ -580,7 +588,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * Damage application targeting both selected token and target.
 * Degree of success display regression on weapon attacks.
 
-[Unreleased]: https://github.com/VacantFanatic/sla-foundry/compare/2.5.0...HEAD
+[Unreleased]: https://github.com/VacantFanatic/sla-foundry/compare/2.5.4...HEAD
+[2.5.4]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.4
+[2.5.3]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.3
+[2.5.2]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.2
+[2.5.1]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.1
 [2.5.0]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.0
 [2.4.7]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.4.7
 [2.4.6]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.4.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sla-industries",
-  "version": "2.5.0",
+  "version": "2.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sla-industries",
-      "version": "2.5.0",
+      "version": "2.5.4",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.49.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sla-industries",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "CSS compiler for the SLA Industries system",
   "scripts": {
     "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",
@@ -10,7 +10,7 @@
     "validate:dist": "node scripts/validate-dist.mjs",
     "validate:package": "node scripts/validate-dist.mjs --zip",
     "watch": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map --watch",
-    "test:unit": "node --test tests/unit/inventory-stack.test.mjs tests/unit/system-manifest.test.mjs tests/unit/dice.test.mjs tests/unit/chat-wound-options.test.mjs tests/unit/ebb-mos.test.mjs tests/unit/build-dist.test.mjs",
+    "test:unit": "node --test tests/unit/inventory-stack.test.mjs tests/unit/system-manifest.test.mjs tests/unit/dice.test.mjs tests/unit/chat-wound-options.test.mjs tests/unit/ebb-mos.test.mjs tests/unit/build-dist.test.mjs tests/unit/update-foundry-release.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:regression": "playwright test tests/e2e/regression-sla.spec.js",
     "test:e2e:operators": "playwright test tests/e2e/regression-operators.spec.js",

--- a/scripts/update-foundry-release.mjs
+++ b/scripts/update-foundry-release.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Notify Foundry's package API about a newly published GitHub release.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const foundryReleaseApi = "https://api.foundryvtt.com/_api/packages/release_version/";
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function encodePathSegment(value) {
+    return encodeURIComponent(value);
+}
+
+/**
+ * @param {string} filePath
+ * @returns {Record<string, any>}
+ */
+export function readJsonFile(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+/**
+ * @param {Record<string, any>} manifest
+ */
+function compatibilityFromManifest(manifest) {
+    return {
+        minimum: manifest.compatibility?.minimum,
+        verified: manifest.compatibility?.verified,
+        maximum: manifest.compatibility?.maximum
+    };
+}
+
+/**
+ * @param {Record<string, any>} event
+ * @param {string} assetName
+ * @returns {string | undefined}
+ */
+function releaseAssetUrl(event, assetName) {
+    const asset = event.release?.assets?.find((entry) => entry?.name === assetName);
+    return asset?.browser_download_url;
+}
+
+/**
+ * @param {Record<string, any>} manifest
+ * @param {Record<string, any>} event
+ * @param {{ dryRun?: boolean, manifestFileName?: string }} [options]
+ */
+export function buildFoundryReleasePayload(manifest, event, options = {}) {
+    const manifestFileName = options.manifestFileName ?? "system.json";
+    const repository = event.repository?.full_name;
+    const tagName = event.release?.tag_name ?? manifest.version;
+
+    if (!manifest.id) {
+        throw new Error("system.json must define an id for the Foundry package release");
+    }
+    if (!manifest.version) {
+        throw new Error("system.json must define a version for the Foundry package release");
+    }
+    if (!repository) {
+        throw new Error("GitHub release event must include repository.full_name");
+    }
+
+    const manifestUrl =
+        releaseAssetUrl(event, manifestFileName) ??
+        `https://github.com/${repository}/releases/download/${encodePathSegment(
+            tagName
+        )}/${manifestFileName}`;
+
+    return {
+        id: manifest.id,
+        "dry-run": options.dryRun ?? false,
+        release: {
+            version: manifest.version,
+            manifest: manifestUrl,
+            notes:
+                event.release?.html_url ??
+                `https://github.com/${repository}/releases/tag/${encodePathSegment(tagName)}`,
+            compatibility: compatibilityFromManifest(manifest)
+        }
+    };
+}
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function envFlag(value) {
+    return value.toLowerCase() === "true";
+}
+
+async function runCli() {
+    const token = process.env.FOUNDRY_PACKAGE_RELEASE_TOKEN;
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    const dryRun = envFlag(process.env.FOUNDRY_DRY_RUN ?? "false");
+
+    if (!token) {
+        throw new Error("FOUNDRY_PACKAGE_RELEASE_TOKEN is required");
+    }
+    if (!eventPath) {
+        throw new Error("GITHUB_EVENT_PATH is required");
+    }
+
+    const manifest = readJsonFile(path.join(root, "system.json"));
+    const event = readJsonFile(eventPath);
+    const payload = buildFoundryReleasePayload(manifest, event, { dryRun });
+
+    const response = await fetch(foundryReleaseApi, {
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: token
+        },
+        method: "POST",
+        body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+        const body = await response.text();
+        throw new Error(
+            `Foundry release update failed (${response.status} ${response.statusText}): ${body}`
+        );
+    }
+
+    console.log(`Foundry package release updated for ${payload.id} ${payload.release.version}`);
+}
+
+const isMain =
+    process.argv[1] &&
+    path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+    runCli().catch((error) => {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+    });
+}

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "compatibility": {
     "minimum": "14",
     "verified": "14.360"
@@ -50,7 +50,7 @@
   ],
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.3/sla-industries.zip",
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.4/sla-industries.zip",
   "packs": [
     {
       "name": "skills",

--- a/tests/unit/update-foundry-release.test.mjs
+++ b/tests/unit/update-foundry-release.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { buildFoundryReleasePayload } from "../../scripts/update-foundry-release.mjs";
+
+const manifest = {
+    id: "sla-industries",
+    version: "2.5.4",
+    compatibility: {
+        minimum: "14",
+        verified: "14.360"
+    }
+};
+
+const releaseEvent = {
+    repository: {
+        full_name: "VacantFanatic/sla-foundry"
+    },
+    release: {
+        tag_name: "2.5.4",
+        html_url: "https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.4",
+        assets: [
+            {
+                name: "system.json",
+                browser_download_url:
+                    "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.4/system.json"
+            }
+        ]
+    }
+};
+
+describe("Foundry release updater", () => {
+    it("uses the manifest package id and published release asset URL", () => {
+        const payload = buildFoundryReleasePayload(manifest, releaseEvent);
+
+        assert.deepEqual(payload, {
+            id: "sla-industries",
+            "dry-run": false,
+            release: {
+                version: "2.5.4",
+                manifest:
+                    "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.4/system.json",
+                notes: "https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.4",
+                compatibility: {
+                    minimum: "14",
+                    verified: "14.360",
+                    maximum: undefined
+                }
+            }
+        });
+    });
+
+    it("falls back to a versioned release URL without adding a v prefix", () => {
+        const payload = buildFoundryReleasePayload(manifest, {
+            ...releaseEvent,
+            release: {
+                tag_name: "2.5.4",
+                html_url: "https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.4",
+                assets: []
+            }
+        });
+
+        assert.equal(
+            payload.release.manifest,
+            "https://github.com/VacantFanatic/sla-foundry/releases/download/2.5.4/system.json"
+        );
+    });
+
+    it("honors dry-run mode", () => {
+        const payload = buildFoundryReleasePayload(manifest, releaseEvent, { dryRun: true });
+
+        assert.equal(payload["dry-run"], true);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Skip versioned GitHub release creation when a non-draft release already exists, avoiding immutable-release update failures on same-version main pushes.
- Replace the Foundry website update third-party action with a repo-local updater that uses the manifest package id and actual published release asset URL.
- Bump release metadata to 2.5.4 and document the CI release fixes.

## Testing
- `npm ci`
- `npm run test:unit`
- `npm run package`
- `node scripts/validate-dist.mjs --zip`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50b06194-a2f8-44d2-ad0f-c0b24bc7b071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50b06194-a2f8-44d2-ad0f-c0b24bc7b071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

