### PR TITLE
Potential fix for code scanning alert no. 2: Shell command built from environment values

### DIFF
--- a/scripts/validate-dist.mjs
+++ b/scripts/validate-dist.mjs
@@ -5,7 +5,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const distDir = path.join(root, "dist");
@@ -99,7 +99,7 @@ export function validateZip(zipFile = zipPath) {
 
     let listing;
     try {
-        listing = execSync(`unzip -Z1 ${JSON.stringify(zipFile)}`, { encoding: "utf8" });
+        listing = execFileSync("unzip", ["-Z1", zipFile], { encoding: "utf8" });
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         throw new Error(`failed to list zip: ${message}`);


### PR DESCRIPTION
Potential fix for [https://github.com/VacantFanatic/sla-foundry/security/code-scanning/2](https://github.com/VacantFanatic/sla-foundry/security/code-scanning/2)

Use a non-shell process execution API for the zip listing call.

Best fix: in `scripts/validate-dist.mjs` at `validateZip` (around line 102), replace:

- `execSync(\`unzip -Z1 ${...}\`, { encoding: "utf8" })`

with:

- `execFileSync("unzip", ["-Z1", zipFile], { encoding: "utf8" })`

and update the child_process import to include `execFileSync` instead of `execSync`.

This keeps functionality the same (still runs `unzip -Z1 <zipFile>` and reads UTF-8 output) while preventing shell interpretation of dynamic path values. No change is required in `tests/unit/build-dist.test.mjs`; that variant is resolved because it calls the now-safe `validateZip`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
