### PR TITLE
Fix Cursor Cloud startup install

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
-  "install": "npm install && npm run test:e2e:install && bash scripts/cloud-foundry.sh prepare",
+  "install": "npm ci && npm run test:e2e:install && bash scripts/cloud-foundry.sh prepare",
   "start": "sudo service docker start 2>/dev/null || true; bash scripts/cloud-foundry.sh start || true"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Cloud agents can develop and verify this repo **without** Foundry license secret
 
 | Task | Command |
 |------|---------|
-| Install JS deps | `npm install` |
+| Install JS deps | `npm ci` |
 | Compile SCSS | `npm run build` (or `npm run watch` while editing styles) |
 | Unit tests | `npm run test:unit` (Node built-in test runner; no Foundry required) |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 * **CI release publishing:** Main CI skips GitHub release creation when the versioned release already exists, avoiding immutable-release update failures on same-version main pushes.
+* **Cursor Cloud startup:** Environment installs use `npm ci`, and `cloud-foundry.sh prepare` no longer requires `rsync` to copy `dist/` into Foundry data.
 * **Foundry website update:** Replaced the third-party post-release action with a repo-local updater that uses the `system.json` package id (`sla-industries`) and the published release asset URL without forcing a `v` tag prefix.
 * Updated system and package metadata version to `2.5.4`, including the release `download` URL in `system.json`.
 

--- a/scripts/cloud-foundry.sh
+++ b/scripts/cloud-foundry.sh
@@ -24,8 +24,8 @@ sync_system_install() {
     exit 1
   fi
   rm -rf "$dest"
-  mkdir -p "$DATA_DIR/Data/systems"
-  rsync -a "$ROOT/dist/" "$dest/"
+  mkdir -p "$dest"
+  cp -a "$ROOT/dist/." "$dest/"
 }
 
 ensure_world_json() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Use `npm ci` in the Cursor Cloud install hook for deterministic dependency installs.
- Replace the `rsync` dependency in `cloud-foundry.sh prepare` with `cp -a`, fixing startup on base images without `rsync`.
- Update agent docs and changelog for the startup install fix.

## Testing
- `bash scripts/cloud-foundry.sh prepare`
- `bash scripts/cloud-foundry.sh prepare && npm run test:unit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50b06194-a2f8-44d2-ad0f-c0b24bc7b071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50b06194-a2f8-44d2-ad0f-c0b24bc7b071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

