### PR TITLE
Add persistent Foundry Docker startup for cloud agents

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
-  "install": "npm ci && npm run test:e2e:install && bash scripts/cloud-foundry.sh prepare",
-  "start": "sudo service docker start 2>/dev/null || true; bash scripts/cloud-foundry.sh start || true"
+  "install": "sudo apt-get update -qq && sudo apt-get install -y -qq docker.io curl ripgrep && chmod +x scripts/*.sh && npm ci && npm run test:e2e:install && bash scripts/cloud-foundry.sh prepare",
+  "start": "bash scripts/cloud-foundry.sh start || true"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,18 @@ bash scripts/cloud-foundry.sh start   # preferred: copies system, creates sla-te
 npm run test:env                      # build + unit + E2E when Foundry is up
 ```
 
+#### Docker persistence (cloud VM)
+
+Foundry runs in Docker via `scripts/start-foundry.sh` with data bind-mounted to **`/home/ubuntu/foundry-data`** (survives agent sessions on the same VM):
+
+| Path | Purpose |
+|------|---------|
+| `/home/ubuntu/foundry-data/Data/` | Worlds, systems, users |
+| `/home/ubuntu/foundry-data/container_cache/foundryvtt-*.zip` | One-time Foundry download (reused after first install) |
+| `/home/ubuntu/foundry-data/Config/` | Server options (preserved with `CONTAINER_PRESERVE_CONFIG=true`) |
+
+The container uses `--restart unless-stopped` and a stable `--hostname foundry-server` (license binding). **Timed `FOUNDRY_RELEASE_URL` values expire in minutes** — refresh at [foundryvtt.com/me/licenses](https://foundryvtt.com/me/licenses) if startup fails with HTTP 403, or add `FOUNDRY_USERNAME` + `FOUNDRY_ACCOUNT_PASSWORD` instead. After the first successful download, the zip in `container_cache/` makes the timed URL unnecessary.
+
 Release builds use **`dist/`** (runtime files only). `npm run build` compiles SCSS and assembles `dist/`; `npm run package` creates `sla-industries.zip`. `cloud-foundry.sh` deploys **`dist/`** into Foundry data (not the full git tree). The test world id is `sla-test-world` (`FOUNDRY_WORLD` / `FOUNDRY_WORLD_ID`). Run `node scripts/ensure-foundry-user.mjs` if `FOUNDRY_USER` is not on the join page yet.
 
 If cloud secrets are not configured, export the same variables in your shell (or pass them only for that command) before running the script — Foundry cannot be downloaded without them.

--- a/scripts/cache-foundry-release.sh
+++ b/scripts/cache-foundry-release.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Download Foundry release zip into container_cache for offline / persistent installs.
+set -euo pipefail
+
+DATA_DIR="${FOUNDRY_DATA_DIR:-/home/ubuntu/foundry-data}"
+CACHE_DIR="$DATA_DIR/container_cache"
+IMAGE="${FOUNDRY_IMAGE:-ghcr.io/felddy/foundryvtt:14}"
+
+mkdir -p "$CACHE_DIR"
+
+if compgen -G "${CACHE_DIR}/foundryvtt-"*.zip >/dev/null 2>&1; then
+  echo "Foundry release cache present in $CACHE_DIR"
+  exit 0
+fi
+
+build="$(sudo docker run --rm --entrypoint printenv "$IMAGE" FOUNDRY_VERSION 2>/dev/null || echo "14.363")"
+zip_path="${CACHE_DIR}/foundryvtt-${build}.zip"
+
+release_url="${FOUNDRY_RELEASE_URL:-}"
+if [[ -n "$release_url" ]]; then
+  code="$(curl -sS -o /dev/null -w "%{http_code}" -I -L --max-time 15 "$release_url" || echo "000")"
+  if [[ "$code" == "200" || "$code" == "302" ]]; then
+    echo "Caching Foundry ${build} release to $zip_path ..."
+    curl -fsSL "$release_url" -o "$zip_path"
+    echo "Cached $(du -h "$zip_path" | cut -f1) release."
+    exit 0
+  fi
+  echo "FOUNDRY_RELEASE_URL returned HTTP $code (timed URLs expire in minutes)." >&2
+fi
+
+echo "No Foundry release in $CACHE_DIR." >&2
+echo "Refresh FOUNDRY_RELEASE_URL in Cloud Agents secrets, or add FOUNDRY_USERNAME + FOUNDRY_ACCOUNT_PASSWORD." >&2
+exit 1

--- a/scripts/cloud-foundry.sh
+++ b/scripts/cloud-foundry.sh
@@ -3,12 +3,12 @@
 # Credentials come from Cloud Agents → Secrets (workspace), not from the repo.
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DATA_DIR="${FOUNDRY_DATA_DIR:-/home/ubuntu/foundry-data}"
 IMAGE="${FOUNDRY_IMAGE:-ghcr.io/felddy/foundryvtt:14}"
 PORT="${FOUNDRY_PORT:-30000}"
 WORLD_ID="${FOUNDRY_WORLD_ID:-sla-test-world}"
-START_SCRIPT="${FOUNDRY_START_SCRIPT:-/home/ubuntu/start-foundry.sh}"
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+START_SCRIPT="${FOUNDRY_START_SCRIPT:-$ROOT/scripts/start-foundry.sh}"
 
 cmd="${1:-status}"
 
@@ -57,6 +57,9 @@ prepare() {
   mkdir -p "$DATA_DIR/Data/systems" "$DATA_DIR/Data/worlds" "$DATA_DIR/container_cache"
   sync_system_install
   ensure_world_json
+  if [[ -x "$ROOT/scripts/cache-foundry-release.sh" ]]; then
+    "$ROOT/scripts/cache-foundry-release.sh" || true
+  fi
   if command -v docker >/dev/null 2>&1; then
     sudo docker pull "$IMAGE" >/dev/null 2>&1 || sudo docker pull "$IMAGE"
   fi

--- a/scripts/start-foundry.sh
+++ b/scripts/start-foundry.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Start Foundry VTT in Docker with persistent data under FOUNDRY_DATA_DIR.
+# Used by scripts/cloud-foundry.sh on Cursor Cloud VMs.
+set -euo pipefail
+
+DATA_DIR="${FOUNDRY_DATA_DIR:-/home/ubuntu/foundry-data}"
+IMAGE="${FOUNDRY_IMAGE:-ghcr.io/felddy/foundryvtt:14}"
+PORT="${FOUNDRY_PORT:-30000}"
+HOSTNAME="${FOUNDRY_DOCKER_HOSTNAME:-foundry-server}"
+WORLD="${FOUNDRY_WORLD:-${FOUNDRY_WORLD_ID:-sla-test-world}}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker not found — install docker.io first." >&2
+  exit 1
+fi
+
+ensure_docker_daemon() {
+  if sudo docker info >/dev/null 2>&1; then
+    return 0
+  fi
+  if command -v service >/dev/null 2>&1; then
+    sudo service docker start 2>/dev/null || true
+    sudo docker info >/dev/null 2>&1 && return 0
+  fi
+  # vfs avoids overlayfs whiteout failures on nested cloud VMs.
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    sudo mkdir -p /etc/docker
+    echo '{"storage-driver":"vfs"}' | sudo tee /etc/docker/daemon.json >/dev/null
+  fi
+  sudo dockerd >/tmp/dockerd.log 2>&1 &
+  for _ in $(seq 1 30); do
+    sudo docker info >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+  echo "Docker daemon failed to start — see /tmp/dockerd.log" >&2
+  return 1
+}
+
+ensure_docker_daemon
+
+mkdir -p "$DATA_DIR/container_cache" "$DATA_DIR/Data/systems" "$DATA_DIR/Data/worlds"
+
+ENV_ARGS=(
+  -e "FOUNDRY_TELEMETRY=false"
+  -e "FOUNDRY_WORLD=${WORLD}"
+  -e "CONTAINER_CACHE=/data/container_cache"
+  -e "CONTAINER_PRESERVE_CONFIG=true"
+)
+
+[[ -n "${FOUNDRY_LICENSE_KEY:-}" ]] && ENV_ARGS+=(-e "FOUNDRY_LICENSE_KEY=${FOUNDRY_LICENSE_KEY}")
+[[ -n "${FOUNDRY_USERNAME:-}" ]] && ENV_ARGS+=(-e "FOUNDRY_USERNAME=${FOUNDRY_USERNAME}")
+[[ -n "${FOUNDRY_ACCOUNT_PASSWORD:-}" ]] && ENV_ARGS+=(-e "FOUNDRY_PASSWORD=${FOUNDRY_ACCOUNT_PASSWORD}")
+
+# Prefer cached zip; only pass timed URL when cache is missing and URL still works.
+cache_zip="$(compgen -G "${DATA_DIR}/container_cache/foundryvtt-"*.zip 2>/dev/null | head -1 || true)"
+if [[ -z "$cache_zip" && -n "${FOUNDRY_RELEASE_URL:-}" ]]; then
+  code="$(curl -sS -o /dev/null -w "%{http_code}" -I -L --max-time 15 "${FOUNDRY_RELEASE_URL}" || echo "000")"
+  if [[ "$code" == "200" || "$code" == "302" ]]; then
+    ENV_ARGS+=(-e "FOUNDRY_RELEASE_URL=${FOUNDRY_RELEASE_URL}")
+  else
+    echo "Skipping expired FOUNDRY_RELEASE_URL (HTTP $code). Run scripts/cache-foundry-release.sh after refreshing secrets." >&2
+  fi
+fi
+
+echo "Pulling ${IMAGE}..."
+sudo docker pull "$IMAGE"
+
+sudo docker rm -f foundry 2>/dev/null || true
+
+echo "Starting Foundry (world=${WORLD}, data=${DATA_DIR})..."
+sudo docker run -d --name foundry \
+  --hostname "$HOSTNAME" \
+  --restart unless-stopped \
+  -p "${PORT}:30000" \
+  -v "${DATA_DIR}:/data" \
+  "${ENV_ARGS[@]}" \
+  "$IMAGE"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up Foundry VTT in Docker on Cursor Cloud VMs with data that persists across agent sessions.

## Changes

- **`scripts/start-foundry.sh`** — Starts `ghcr.io/felddy/foundryvtt:14` with:
  - Bind mount: `/home/ubuntu/foundry-data` → `/data`
  - `--restart unless-stopped` and stable hostname `foundry-server`
  - `CONTAINER_CACHE` + `CONTAINER_PRESERVE_CONFIG` for config/world persistence
  - Docker `vfs` storage driver bootstrap for nested cloud VMs (overlayfs whiteout fix)
- **`scripts/cache-foundry-release.sh`** — Downloads Foundry zip into `container_cache/` when a valid timed URL is available (one-time; reused thereafter)
- **`scripts/cloud-foundry.sh`** — Uses repo-local start script; runs cache step during `prepare`
- **`.cursor/environment.json`** — Installs Docker on VM boot
- **`AGENTS.md`** — Documents persistence paths and timed URL expiry

## Usage

```bash
bash scripts/cloud-foundry.sh start
```

After the first successful install, worlds/systems and the cached release zip live under `/home/ubuntu/foundry-data` and survive session restarts.

## Note

`FOUNDRY_RELEASE_URL` timed links expire quickly. If startup fails with HTTP 403, refresh the secret at [foundryvtt.com/me/licenses](https://foundryvtt.com/me/licenses) or add `FOUNDRY_USERNAME` + `FOUNDRY_ACCOUNT_PASSWORD`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29667a7c-2086-4f8f-8d52-277c69420094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29667a7c-2086-4f8f-8d52-277c69420094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

