### PR TITLE
Fix Cursor Cloud Foundry startup readiness (v2.6.1)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,4 +1,4 @@
 {
-  "install": "sudo apt-get update -qq && sudo apt-get install -y -qq docker.io curl ripgrep && chmod +x scripts/*.sh && npm ci && npm run test:e2e:install && bash scripts/cloud-foundry.sh prepare",
-  "start": "bash scripts/cloud-foundry.sh start || true"
+  "install": "sudo apt-get update -qq && sudo apt-get install -y -qq docker.io curl ripgrep && chmod +x scripts/*.sh && npm ci && npm run test:e2e:install && bash scripts/ensure-docker.sh && bash scripts/cloud-foundry.sh prepare",
+  "start": "bash scripts/cloud-foundry.sh start"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,9 @@ Configure these in **Cloud Agents → Secrets** (one download method is enough):
 Start server after secrets are set:
 
 ```bash
-bash scripts/cloud-foundry.sh start   # preferred: copies system, creates sla-test-world, auto-launches
-npm run test:env                      # build + unit + E2E when Foundry is up
+bash scripts/cloud-foundry.sh start   # preferred: copies system, creates sla-test-world, launches when /join is ready
+bash scripts/cloud-foundry.sh bootstrap  # first boot: EULA + world launch + FOUNDRY_USER
+npm run test:env                      # build + unit + E2E when /join is ready (not merely port open)
 ```
 
 #### Docker persistence (cloud VM)
@@ -62,7 +63,7 @@ Foundry runs in Docker via `scripts/start-foundry.sh` with data bind-mounted to 
 
 The container uses `--restart unless-stopped` and a stable `--hostname foundry-server` (license binding). **Timed `FOUNDRY_RELEASE_URL` values expire in minutes** — refresh at [foundryvtt.com/me/licenses](https://foundryvtt.com/me/licenses) if startup fails with HTTP 403, or add `FOUNDRY_USERNAME` + `FOUNDRY_ACCOUNT_PASSWORD` instead. After the first successful download, the zip in `container_cache/` makes the timed URL unnecessary.
 
-Release builds use **`dist/`** (runtime files only). `npm run build` compiles SCSS and assembles `dist/`; `npm run package` creates `sla-industries.zip`. `cloud-foundry.sh` deploys **`dist/`** into Foundry data (not the full git tree). The test world id is `sla-test-world` (`FOUNDRY_WORLD` / `FOUNDRY_WORLD_ID`). Run `node scripts/ensure-foundry-user.mjs` if `FOUNDRY_USER` is not on the join page yet.
+Release builds use **`dist/`** (runtime files only). `npm run build` compiles SCSS and assembles `dist/`; `npm run package` creates `sla-industries.zip`. `cloud-foundry.sh` deploys **`dist/`** into Foundry data (not the full git tree). The test world id is `sla-test-world` (`FOUNDRY_WORLD` / `FOUNDRY_WORLD_ID`). Run `bash scripts/cloud-foundry.sh bootstrap` (or `node scripts/ensure-foundry-user.mjs`) if `FOUNDRY_USER` is not on the join page yet. `foundry:status` requires a joinable world; `foundry:starting` means the server is up but EULA/world launch is still pending.
 
 If cloud secrets are not configured, export the same variables in your shell (or pass them only for that command) before running the script — Foundry cannot be downloaded without them.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.6.1] - 2026-06-05
+
+### Fixed
+
+* **Cursor Cloud Foundry startup:** `foundry_join_ready` checks v14 `/join` static HTML (`auth join` body, not “Critical Failure”) instead of treating any HTTP response as ready; `status` reports `foundry:starting` when the server is up but the world is not joinable.
+* **Docker on cloud VMs:** Shared `scripts/ensure-docker.sh` starts `dockerd` (vfs driver) before `prepare`/`start` use Docker; wired into `environment.json` install.
+* **First-boot automation:** `cloud-foundry.sh start` runs `foundry-bootstrap.mjs` (EULA, `worldLaunch`) when HTTP is up but `/join` is not; `bootstrap` subcommand waits for join readiness before creating `FOUNDRY_USER`.
+* **`ensure-foundry-user.mjs`:** Retries until `/join` lists users; no longer calls `game.shutDown()` (which stopped the world and broke subsequent E2E).
+* **`foundry-bootstrap.mjs`:** Updated for Foundry v14 UI (`#eula-agree`, `[data-action="worldLaunch"]`, 1920×1080 viewport).
+* **`environment.json` / `test-environment.sh`:** Removed `|| true` on start so startup failures surface to Cursor and CI.
+
 ## [2.6.0] - 2026-06-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sla-industries",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "CSS compiler for the SLA Industries system",
   "scripts": {
     "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",

--- a/scripts/cloud-foundry.sh
+++ b/scripts/cloud-foundry.sh
@@ -9,6 +9,8 @@ IMAGE="${FOUNDRY_IMAGE:-ghcr.io/felddy/foundryvtt:14}"
 PORT="${FOUNDRY_PORT:-30000}"
 WORLD_ID="${FOUNDRY_WORLD_ID:-sla-test-world}"
 START_SCRIPT="${FOUNDRY_START_SCRIPT:-$ROOT/scripts/start-foundry.sh}"
+# shellcheck source=ensure-docker.sh
+source "$ROOT/scripts/ensure-docker.sh"
 
 cmd="${1:-status}"
 
@@ -54,6 +56,9 @@ clear_stale_lock() {
 }
 
 prepare() {
+  if command -v docker >/dev/null 2>&1; then
+    ensure_docker_daemon
+  fi
   mkdir -p "$DATA_DIR/Data/systems" "$DATA_DIR/Data/worlds" "$DATA_DIR/container_cache"
   sync_system_install
   ensure_world_json
@@ -74,37 +79,63 @@ has_cache_zip() {
   compgen -G "$DATA_DIR/container_cache/foundryvtt-"*.zip >/dev/null 2>&1
 }
 
-foundry_listening() {
-  curl -sf --max-time 2 "http://127.0.0.1:${PORT}/join" 2>/dev/null | rg -q "Join Game Session" || \
-    curl -sf --max-time 2 "http://127.0.0.1:${PORT}/" >/dev/null 2>&1
+# Join page is ready — world is running (v14 serves /join as a client app; static HTML only).
+foundry_join_ready() {
+  local html
+  html="$(curl -sf --max-time 2 "http://127.0.0.1:${PORT}/join" 2>/dev/null)" || return 1
+  echo "$html" | rg -q 'class="auth join' || return 1
+  echo "$html" | rg -qi 'critical failure' && return 1
+  return 0
+}
+
+# HTTP responds (license, setup, or join) but join may not be ready yet.
+foundry_http_up() {
+  curl -sf --max-time 2 "http://127.0.0.1:${PORT}/" >/dev/null 2>&1
+}
+
+wait_for_join_ready() {
+  local attempts="${1:-120}"
+  for _ in $(seq 1 "$attempts"); do
+    if foundry_join_ready; then
+      return 0
+    fi
+    sleep 2
+  done
+  return 1
+}
+
+run_first_boot_bootstrap() {
+  if foundry_join_ready; then
+    return 0
+  fi
+  if ! foundry_http_up; then
+    echo "Foundry HTTP not responding — cannot run first-boot bootstrap." >&2
+    return 1
+  fi
+  echo "Foundry HTTP up but /join not ready — running first-boot bootstrap..."
+  node "$ROOT/scripts/foundry-bootstrap.mjs"
 }
 
 bootstrap_users() {
   if [[ -z "${FOUNDRY_USER:-}" ]]; then
     return 0
   fi
-  if ! foundry_listening; then
+  if ! foundry_join_ready; then
+    echo "Skipping user bootstrap — /join is not ready." >&2
     return 0
   fi
-  node "$ROOT/scripts/ensure-foundry-user.mjs" || true
+  node "$ROOT/scripts/ensure-foundry-user.mjs"
 }
 
-start() {
-  prepare
-  clear_stale_lock
-
-  if foundry_listening; then
-    echo "Foundry already listening on http://127.0.0.1:${PORT}"
-    bootstrap_users
-    return 0
-  fi
-
+start_container() {
   export FOUNDRY_WORLD="${FOUNDRY_WORLD:-$WORLD_ID}"
 
   if has_download_creds && [[ -x "$START_SCRIPT" ]]; then
     echo "Starting Foundry via credentials (world=$FOUNDRY_WORLD)..."
     "$START_SCRIPT"
-  elif has_cache_zip; then
+    return 0
+  fi
+  if has_cache_zip; then
     echo "Starting Foundry from container cache (world=$FOUNDRY_WORLD)..."
     sudo docker rm -f foundry 2>/dev/null || true
     ENV_ARGS=(-e "FOUNDRY_TELEMETRY=false" -e "FOUNDRY_WORLD=${FOUNDRY_WORLD}")
@@ -112,20 +143,53 @@ start() {
     [[ -n "${FOUNDRY_RELEASE_URL:-}" ]] && ENV_ARGS+=(-e "FOUNDRY_RELEASE_URL=${FOUNDRY_RELEASE_URL}")
     sudo docker run -d --name foundry \
       --hostname "${FOUNDRY_DOCKER_HOSTNAME:-foundry-server}" \
+      --restart unless-stopped \
       -p "${PORT}:30000" \
       -v "${DATA_DIR}:/data" \
       "${ENV_ARGS[@]}" \
       "$IMAGE"
-  else
-    echo "Foundry not started: add Cloud Agents secrets (see AGENTS.md)."
+    return 0
+  fi
+  echo "Foundry not started: add Cloud Agents secrets (see AGENTS.md)." >&2
+  return 1
+}
+
+finish_start() {
+  if ! wait_for_join_ready 120; then
+    run_first_boot_bootstrap || true
+    if ! wait_for_join_ready 60; then
+      echo "Foundry /join not ready after bootstrap. sudo docker logs foundry" >&2
+      return 1
+    fi
+  fi
+  echo "Foundry join page ready at http://127.0.0.1:${PORT}"
+  bootstrap_users
+}
+
+start() {
+  prepare
+  clear_stale_lock
+
+  if foundry_join_ready; then
+    echo "Foundry join page already ready at http://127.0.0.1:${PORT}"
+    bootstrap_users
     return 0
   fi
 
+  if foundry_http_up; then
+    echo "Foundry HTTP responding but /join not ready..."
+    run_first_boot_bootstrap || true
+    finish_start
+    return $?
+  fi
+
+  start_container || return 0
+
   for _ in $(seq 1 120); do
-    if foundry_listening; then
-      echo "Foundry is up at http://127.0.0.1:${PORT}"
-      bootstrap_users
-      return 0
+    if foundry_http_up; then
+      run_first_boot_bootstrap || true
+      finish_start
+      return $?
     fi
     sleep 2
   done
@@ -134,9 +198,13 @@ start() {
 }
 
 status() {
-  if foundry_listening; then
+  if foundry_join_ready; then
     echo "foundry:up http://127.0.0.1:${PORT}"
     return 0
+  fi
+  if foundry_http_up; then
+    echo "foundry:starting http://127.0.0.1:${PORT}"
+    return 1
   fi
   echo "foundry:down"
   return 1
@@ -146,6 +214,16 @@ case "$cmd" in
   prepare) prepare ;;
   start) start ;;
   status) status ;;
-  bootstrap) prepare; bootstrap_users ;;
+  bootstrap)
+    prepare
+    if ! foundry_join_ready; then
+      run_first_boot_bootstrap || true
+      wait_for_join_ready 60 || {
+        echo "Bootstrap failed: /join not ready." >&2
+        exit 1
+      }
+    fi
+    bootstrap_users
+    ;;
   *) echo "Usage: $0 {prepare|start|status|bootstrap}" >&2; exit 1 ;;
 esac

--- a/scripts/ensure-docker.sh
+++ b/scripts/ensure-docker.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Start the Docker daemon on Cursor Cloud VMs (no systemd; vfs storage on nested hosts).
+set -euo pipefail
+
+ensure_docker_daemon() {
+  if sudo docker info >/dev/null 2>&1; then
+    return 0
+  fi
+  if command -v service >/dev/null 2>&1; then
+    sudo service docker start 2>/dev/null || true
+    sudo docker info >/dev/null 2>&1 && return 0
+  fi
+  # vfs avoids overlayfs whiteout failures on nested cloud VMs.
+  if [[ ! -f /etc/docker/daemon.json ]]; then
+    sudo mkdir -p /etc/docker
+    echo '{"storage-driver":"vfs"}' | sudo tee /etc/docker/daemon.json >/dev/null
+  fi
+  sudo dockerd >/tmp/dockerd.log 2>&1 &
+  for _ in $(seq 1 30); do
+    sudo docker info >/dev/null 2>&1 && return 0
+    sleep 1
+  done
+  echo "Docker daemon failed to start — see /tmp/dockerd.log" >&2
+  return 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  ensure_docker_daemon
+fi

--- a/scripts/ensure-foundry-user.mjs
+++ b/scripts/ensure-foundry-user.mjs
@@ -8,32 +8,50 @@ import { chromium } from "@playwright/test";
 const base = process.env.FOUNDRY_URL || "http://127.0.0.1:30000";
 const targetName = process.env.FOUNDRY_USER;
 const targetPassword = process.env.FOUNDRY_PASSWORD ?? "";
+const maxWaitMs = Number(process.env.FOUNDRY_JOIN_WAIT_MS || 300_000);
+const pollMs = 5_000;
 
 if (!targetName) {
     console.error("FOUNDRY_USER is required");
     process.exit(1);
 }
 
+async function waitForJoinUsers(page) {
+    const deadline = Date.now() + maxWaitMs;
+    while (Date.now() < deadline) {
+        await page.goto(`${base}/join`, { waitUntil: "networkidle", timeout: 60_000 });
+        const labels = await page.locator("select[name='userid'] option").allTextContents();
+        const names = labels.map((l) => l.trim()).filter(Boolean);
+        if (names.length) {
+            return names;
+        }
+        console.log("Waiting for /join user list...");
+        await page.waitForTimeout(pollMs);
+    }
+    const snippet = await page.locator("body").innerText().catch(() => "");
+    console.error("/join has no users after waiting.", snippet.slice(0, 300));
+    process.exit(1);
+}
+
+function pickBootstrapUser(names) {
+    if (names.includes("Gamemaster")) return "Gamemaster";
+    return names[0];
+}
+
 const browser = await chromium.launch({ headless: true });
 const page = await browser.newPage();
 await page.setViewportSize({ width: 1920, height: 1080 });
 
-await page.goto(`${base}/join`, { waitUntil: "networkidle", timeout: 60_000 });
-
-const labels = await page.locator("select[name='userid'] option").allTextContents();
-if (labels.some((l) => l.trim() === targetName)) {
+const joinUsers = await waitForJoinUsers(page);
+if (joinUsers.includes(targetName)) {
     console.log(`User "${targetName}" already on join page.`);
     await browser.close();
     process.exit(0);
 }
 
-if (!labels.some((l) => l.trim() === "Gamemaster")) {
-    console.error("Gamemaster user not found; launch sla-test-world first.");
-    process.exit(1);
-}
-
-console.log(`Creating join user "${targetName}" via Gamemaster session...`);
-await page.locator("select[name='userid']").selectOption({ label: "Gamemaster" });
+const bootstrapUser = pickBootstrapUser(joinUsers);
+console.log(`Creating join user "${targetName}" via "${bootstrapUser}" session...`);
+await page.locator("select[name='userid']").selectOption({ label: bootstrapUser });
 await page.getByRole("textbox", { name: /password/i }).fill("");
 await page.getByRole("button", { name: /join game session/i }).click();
 await page.waitForURL(/\/game/, { timeout: 90_000 });
@@ -47,7 +65,7 @@ const created = await page.evaluate(
         const doc = await User.create({
             name,
             role: CONST.USER_ROLES.GAMEMASTER,
-            password: password || undefined
+            password: password || undefined,
         });
         return { ok: Boolean(doc), id: doc?.id };
     },
@@ -60,11 +78,6 @@ if (!created.ok) {
 }
 
 console.log(created.existed ? "User already existed in world data." : `Created user id=${created.id}`);
-
-await page.evaluate(async () => {
-    await game.shutDown();
-});
-await page.waitForURL(/\/join|\/setup/, { timeout: 60_000 }).catch(() => {});
 
 await browser.close();
 console.log("Done.");

--- a/scripts/foundry-bootstrap.mjs
+++ b/scripts/foundry-bootstrap.mjs
@@ -1,213 +1,123 @@
 #!/usr/bin/env node
-import { chromium } from '@playwright/test';
+/**
+ * First-boot UI steps: EULA, license key (if needed), launch sla-test-world.
+ * World JSON is created on disk by cloud-foundry.sh; user creation is ensure-foundry-user.mjs.
+ */
+import { chromium } from "@playwright/test";
 
-const FOUNDRY_URL = 'http://127.0.0.1:30000';
+const FOUNDRY_URL = process.env.FOUNDRY_URL || "http://127.0.0.1:30000";
 const LICENSE_KEY = process.env.FOUNDRY_LICENSE_KEY;
-const USER_NAME = process.env.FOUNDRY_USER;
-const PASSWORD = process.env.FOUNDRY_PASSWORD;
+const WORLD_ID = process.env.FOUNDRY_WORLD_ID || "sla-test-world";
+const JOIN_WAIT_MS = Number(process.env.FOUNDRY_JOIN_WAIT_MS || 300_000);
+
+async function dismissSetupTours(page) {
+    for (let i = 0; i < 5; i++) {
+        await page.keyboard.press("Escape");
+        await page.waitForTimeout(300);
+    }
+    const close = page.locator(".window-header .header-control.close, button.close");
+    if (await close.count()) {
+        await close.first().click({ force: true }).catch(() => {});
+    }
+}
+
+async function acceptLicense(page) {
+    await page.goto(`${FOUNDRY_URL}/license`, { waitUntil: "networkidle", timeout: 60_000 });
+
+    const licenseInput = page.locator('input[name="licenseKey"]');
+    if (LICENSE_KEY && (await licenseInput.count())) {
+        console.log("Submitting license key...");
+        await licenseInput.fill(LICENSE_KEY);
+        await page.locator('button[type="submit"]').click();
+        await page.waitForLoadState("networkidle");
+        return;
+    }
+
+    const eula = page.locator("#eula-agree, input[name='agree']");
+    if (await eula.count()) {
+        console.log("Accepting EULA...");
+        await eula.check();
+        await page.getByRole("button", { name: /^Agree$/i }).click();
+        await page.waitForURL(/\/(setup|join|game)/, { timeout: 60_000 }).catch(() => {});
+    }
+}
+
+async function joinUserNames(page) {
+    const labels = await page.locator("select[name='userid'] option").allTextContents();
+    return labels.map((l) => l.trim()).filter(Boolean);
+}
+
+async function waitForJoinUsers(page) {
+    const deadline = Date.now() + JOIN_WAIT_MS;
+    while (Date.now() < deadline) {
+        await page.goto(`${FOUNDRY_URL}/join`, { waitUntil: "networkidle", timeout: 60_000 });
+        const hasHeading = await page.getByRole("heading", { name: /join game session/i }).count();
+        if (!hasHeading) {
+            await page.waitForTimeout(3000);
+            continue;
+        }
+        const names = await joinUserNames(page);
+        if (names.length) {
+            console.log(`Join page ready (${names.length} user(s)).`);
+            return;
+        }
+        console.log("Join page visible but no users yet — waiting...");
+        await page.waitForTimeout(3000);
+    }
+    throw new Error("/join did not list any users within the wait window.");
+}
+
+async function launchFromSetup(page) {
+    await page.goto(`${FOUNDRY_URL}/setup`, { waitUntil: "networkidle", timeout: 60_000 });
+    await page.waitForTimeout(2000);
+
+    if (page.url().includes("/join")) {
+        console.log("/setup redirected to /join — world may already be running.");
+        return waitForJoinUsers(page);
+    }
+
+    await dismissSetupTours(page);
+
+    const worldCards = page.locator("li.world");
+    const count = await worldCards.count();
+    if (count === 0) {
+        throw new Error(`No worlds on setup page (expected ${WORLD_ID} from ensure_world_json).`);
+    }
+    console.log(`Found ${count} world(s) on setup page.`);
+
+    const target = page.locator(`li.world[data-world-id="${WORLD_ID}"], li.world`).first();
+    await target.click();
+    await page.waitForTimeout(500);
+
+    const launch = page.locator('[data-action="worldLaunch"]');
+    if (!(await launch.count())) {
+        throw new Error("Could not find [data-action=worldLaunch] on setup page.");
+    }
+    console.log("Launching world...");
+    await launch.first().click();
+    await page.waitForURL(/\/(game|join)/, { timeout: 120_000 });
+    return waitForJoinUsers(page);
+}
 
 async function bootstrap() {
-  console.log('Starting Foundry VTT first-time setup...');
-  
-  const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext();
-  const page = await context.newPage();
+    console.log("Starting Foundry first-boot bootstrap...");
+    const browser = await chromium.launch({ headless: true });
+    const page = await browser.newPage();
+    await page.setViewportSize({ width: 1920, height: 1080 });
 
-  try {
-    // Step 1: Handle license page
-    console.log('Step 1: Checking license page...');
-    await page.goto(`${FOUNDRY_URL}/license`, { waitUntil: 'networkidle', timeout: 30000 });
-    await page.screenshot({ path: '/tmp/license-page.png', fullPage: true });
-    console.log('  Screenshot saved to /tmp/license-page.png');
-    
-    // Check if we need to submit license key
-    const licenseInput = await page.locator('input[name="licenseKey"]').count();
-    if (licenseInput > 0) {
-      console.log('  Submitting license key...');
-      await page.fill('input[name="licenseKey"]', LICENSE_KEY);
-      await page.click('button[type="submit"]');
-      await page.waitForLoadState('networkidle');
-      console.log('  License key submitted');
-    } else {
-      console.log('  Checking for EULA agreement...');
-      // Look for EULA checkbox or agreement button
-      const eulaCheckbox = page.locator('input[name="eula"]');
-      const agreeButton = page.locator('button:has-text("agree"), button:has-text("Accept"), button:has-text("Continue")');
-      
-      if (await eulaCheckbox.count() > 0) {
-        console.log('  Checking EULA checkbox...');
-        await eulaCheckbox.check();
-      }
-      
-      if (await agreeButton.count() > 0) {
-        console.log('  Clicking agreement button...');
-        await agreeButton.first().click();
-        await page.waitForLoadState('networkidle');
-        console.log('  License accepted');
-      } else {
-        console.log('  License already accepted');
-      }
+    try {
+        await acceptLicense(page);
+        await launchFromSetup(page);
+        console.log("Foundry first-boot bootstrap complete.");
+        await browser.close();
+        process.exit(0);
+    } catch (error) {
+        console.error("First-boot bootstrap failed:", error.message);
+        await page.screenshot({ path: "/tmp/foundry-setup-error.png", fullPage: true }).catch(() => {});
+        console.error("Screenshot: /tmp/foundry-setup-error.png");
+        await browser.close();
+        process.exit(1);
     }
-
-    // Step 2: Setup page - create world and user
-    console.log('Step 2: Navigating to setup page...');
-    await page.goto(`${FOUNDRY_URL}/setup`, { waitUntil: 'networkidle', timeout: 30000 });
-    await page.screenshot({ path: '/tmp/setup-page.png', fullPage: true });
-    console.log('  Screenshot saved to /tmp/setup-page.png');
-    
-    // Wait a bit for the page to fully render
-    await page.waitForTimeout(2000);
-    
-    // Check if we need to create a world
-    console.log('  Checking for existing worlds...');
-    const worldsList = await page.locator('#worlds-list li.world, .world-entry').count();
-    
-    if (worldsList === 0) {
-      console.log('  Creating new world...');
-      // Try multiple selectors for the create button
-      const createSelectors = [
-        'button[data-action="createWorld"]',
-        'a[data-action="createWorld"]',
-        'button:has-text("Create World")',
-        '#worlds-list button.create-world',
-        '.worlds button.create'
-      ];
-      
-      let createClicked = false;
-      for (const selector of createSelectors) {
-        if (await page.locator(selector).count() > 0) {
-          console.log(`  Found create button: ${selector}`);
-          await page.locator(selector).first().click();
-          createClicked = true;
-          break;
-        }
-      }
-      
-      if (!createClicked) {
-        throw new Error('Could not find create world button');
-      }
-      
-      await page.waitForSelector('form#world-create, form.world-create, .window-content form', { timeout: 10000 });
-      
-      // Fill world creation form
-      await page.fill('input[name="title"]', 'SLA Industries Test World');
-      
-      // Wait for system dropdown to be populated
-      await page.waitForTimeout(1000);
-      await page.selectOption('select[name="system"]', 'sla-industries');
-      
-      await page.click('button[type="submit"]');
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(2000);
-      console.log('  World created');
-    } else {
-      console.log(`  Found ${worldsList} existing world(s)`);
-    }
-
-    // Create user if needed
-    console.log('  Checking for users...');
-    await page.goto(`${FOUNDRY_URL}/setup`, { waitUntil: 'networkidle', timeout: 30000 });
-    await page.waitForTimeout(1000);
-    
-    const usersList = await page.locator('#users-list li.user, .user-entry').count();
-    
-    if (usersList === 0) {
-      console.log('  Creating user...');
-      // Try multiple selectors for create user button
-      const createUserSelectors = [
-        'button[data-action="createUser"]',
-        'a[data-action="createUser"]',
-        'button:has-text("Create User")',
-        '#users-list button.create-user',
-        '.users button.create'
-      ];
-      
-      let createClicked = false;
-      for (const selector of createUserSelectors) {
-        if (await page.locator(selector).count() > 0) {
-          console.log(`  Found create user button: ${selector}`);
-          await page.locator(selector).first().click();
-          createClicked = true;
-          break;
-        }
-      }
-      
-      if (!createClicked) {
-        throw new Error('Could not find create user button');
-      }
-      
-      await page.waitForSelector('form#user-create, form.user-create, .window-content form', { timeout: 10000 });
-      
-      await page.fill('input[name="name"]', USER_NAME);
-      if (PASSWORD) {
-        await page.fill('input[name="password"]', PASSWORD);
-        await page.fill('input[name="passwordConfirm"]', PASSWORD);
-      }
-      // Try to set role to Gamemaster (value might be "4" or "GAMEMASTER")
-      const roleSelect = page.locator('select[name="role"]');
-      if (await roleSelect.count() > 0) {
-        await roleSelect.selectOption({ index: await roleSelect.locator('option').count() - 1 });
-      }
-      
-      await page.click('button[type="submit"]');
-      await page.waitForLoadState('networkidle');
-      await page.waitForTimeout(2000);
-      console.log('  User created');
-    } else {
-      console.log(`  Found ${usersList} existing user(s)`);
-    }
-
-    // Step 3: Launch the world
-    console.log('Step 3: Launching world...');
-    await page.goto(`${FOUNDRY_URL}/setup`, { waitUntil: 'networkidle', timeout: 30000 });
-    await page.waitForTimeout(1000);
-    await page.screenshot({ path: '/tmp/setup-before-launch.png', fullPage: true });
-    
-    // Find and click the launch button for the world
-    const launchSelectors = [
-      'li.world button[data-action="launchWorld"]',
-      'button[data-action="launchWorld"]',
-      'button.launch-world',
-      'button:has-text("Launch")'
-    ];
-    
-    let launched = false;
-    for (const selector of launchSelectors) {
-      if (await page.locator(selector).count() > 0) {
-        console.log(`  Found launch button: ${selector}`);
-        await page.locator(selector).first().click();
-        launched = true;
-        break;
-      }
-    }
-    
-    if (!launched) {
-      throw new Error('Could not find launch world button');
-    }
-    
-    console.log('  Waiting for world to launch...');
-    await page.waitForURL(/\/(game|join)/, { timeout: 60000 });
-    console.log('  World launched successfully');
-
-    // Verify /join is accessible
-    console.log('Step 4: Verifying /join endpoint...');
-    await page.goto(`${FOUNDRY_URL}/join`, { waitUntil: 'networkidle', timeout: 30000 });
-    const joinPage = await page.locator('body').isVisible();
-    if (joinPage) {
-      console.log('  /join is accessible');
-    }
-
-    console.log('\n✓ Foundry VTT setup completed successfully!');
-    await browser.close();
-    process.exit(0);
-
-  } catch (error) {
-    console.error('\n✗ Setup failed:', error.message);
-    await page.screenshot({ path: '/tmp/foundry-setup-error.png', fullPage: true });
-    console.error('Screenshot saved to /tmp/foundry-setup-error.png');
-    await browser.close();
-    process.exit(1);
-  }
 }
 
 bootstrap();

--- a/scripts/start-foundry.sh
+++ b/scripts/start-foundry.sh
@@ -3,6 +3,7 @@
 # Used by scripts/cloud-foundry.sh on Cursor Cloud VMs.
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DATA_DIR="${FOUNDRY_DATA_DIR:-/home/ubuntu/foundry-data}"
 IMAGE="${FOUNDRY_IMAGE:-ghcr.io/felddy/foundryvtt:14}"
 PORT="${FOUNDRY_PORT:-30000}"
@@ -14,28 +15,8 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
-ensure_docker_daemon() {
-  if sudo docker info >/dev/null 2>&1; then
-    return 0
-  fi
-  if command -v service >/dev/null 2>&1; then
-    sudo service docker start 2>/dev/null || true
-    sudo docker info >/dev/null 2>&1 && return 0
-  fi
-  # vfs avoids overlayfs whiteout failures on nested cloud VMs.
-  if [[ ! -f /etc/docker/daemon.json ]]; then
-    sudo mkdir -p /etc/docker
-    echo '{"storage-driver":"vfs"}' | sudo tee /etc/docker/daemon.json >/dev/null
-  fi
-  sudo dockerd >/tmp/dockerd.log 2>&1 &
-  for _ in $(seq 1 30); do
-    sudo docker info >/dev/null 2>&1 && return 0
-    sleep 1
-  done
-  echo "Docker daemon failed to start — see /tmp/dockerd.log" >&2
-  return 1
-}
-
+# shellcheck source=ensure-docker.sh
+source "$ROOT/scripts/ensure-docker.sh"
 ensure_docker_daemon
 
 mkdir -p "$DATA_DIR/container_cache" "$DATA_DIR/Data/systems" "$DATA_DIR/Data/worlds"

--- a/scripts/test-environment.sh
+++ b/scripts/test-environment.sh
@@ -10,7 +10,7 @@ echo "=== SLA Industries environment test ==="
 npm run build
 npm run test:unit
 
-bash scripts/cloud-foundry.sh start || true
+bash scripts/cloud-foundry.sh start
 
 if bash scripts/cloud-foundry.sh status >/dev/null 2>&1; then
   echo "=== Foundry is up — running E2E ==="
@@ -19,14 +19,8 @@ if bash scripts/cloud-foundry.sh status >/dev/null 2>&1; then
   fi
   npm run test:e2e
 else
-  echo "=== Foundry not running — skipping E2E (unit + build passed) ==="
-  bash scripts/cloud-foundry.sh start || true
-  if bash scripts/cloud-foundry.sh status >/dev/null 2>&1; then
-    echo "Foundry came up after start; running E2E..."
-    npm run test:e2e
-  else
-    echo "E2E skipped. Configure Cloud Agents secrets or save a VM snapshot with Foundry installed."
-  fi
+  echo "=== Foundry not ready — skipping E2E (unit + build passed) ==="
+  echo "Configure Cloud Agents secrets or save a VM snapshot with Foundry installed."
 fi
 
 echo "=== Environment test complete ==="

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "compatibility": {
     "minimum": "14",
     "verified": "14.360"
@@ -50,7 +50,7 @@
   ],
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.6.0/sla-industries.zip",
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.6.1/sla-industries.zip",
   "packs": [
     {
       "name": "skills",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Cursor Cloud environment startup sequence so Foundry is only considered ready when the world is joinable, and automates first-boot steps (EULA, world launch, test user).

## Problem

On first boot, `cloud-foundry.sh start` reported success while Foundry was still on the license page or had no active world. E2E tests then failed because `/join` had no user combobox. Contributing issues:

- `foundry_listening()` treated any HTTP 200 as ready (including `/license` and `/setup`)
- `prepare()` called Docker before `dockerd` was started on nested cloud VMs
- `foundry-bootstrap.mjs` was never invoked from the startup pipeline
- `ensure-foundry-user.mjs` called `game.shutDown()`, stopping the world after user creation
- `environment.json` used `|| true`, hiding startup failures

## Changes

- **`scripts/ensure-docker.sh`** — shared Docker daemon startup (vfs driver) for cloud VMs without systemd
- **`scripts/cloud-foundry.sh`**
  - `foundry_join_ready` checks v14 `/join` static HTML (`auth join` body, not "Critical Failure")
  - `status` reports `foundry:starting` when HTTP is up but world is not joinable
  - Runs `foundry-bootstrap.mjs` when needed; new `bootstrap` subcommand
- **`scripts/foundry-bootstrap.mjs`** — v14 selectors (`#eula-agree`, `worldLaunch`), handles `/setup` → `/join` redirect
- **`scripts/ensure-foundry-user.mjs`** — retries until users appear; no longer shuts down the world
- **`.cursor/environment.json`** / **`test-environment.sh`** — start Docker during install; stop swallowing errors

## Version

Bumps to **2.6.1** (patch).

## Test plan

- [x] `npm run test:unit` (26/26)
- [x] `bash scripts/cloud-foundry.sh start` completes in ~2s when world is running
- [x] `bash scripts/cloud-foundry.sh status` → `foundry:up`
- [x] `npm run test:e2e -- tests/e2e/foundry-smoke.spec.js` (2/2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a25cbf2-3ede-4df2-9c9e-38918edb1c2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a25cbf2-3ede-4df2-9c9e-38918edb1c2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

