### PR TITLE
Trigger GitHub releases on version tags instead of main pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: sla-industries CI
 
-permissions:
-  contents: write
-
 on:
   push:
+    branches:
+      - main
+  pull_request:
     branches:
       - main
 
@@ -28,41 +28,8 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
-      - name: Get Version
-        id: get-version
-        run: echo "version=$(node ./.github/workflows/get-version.js)" >> "$GITHUB_OUTPUT"
+      - name: Build dist
+        run: npm run build
 
-      - name: Build and package release zip
-        run: npm run package
-
-      - name: Validate dist and zip artifacts
-        run: node scripts/validate-dist.mjs --zip
-
-      - name: Copy manifest for release asset
-        run: cp dist/system.json system.json
-
-      - name: Create Release
-        id: create_versioned_release
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          skipIfReleaseExists: true
-          name: Release ${{ steps.get-version.outputs.version }}
-          draft: true
-          prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "./system.json,./sla-industries.zip"
-          tag: ${{ steps.get-version.outputs.version }}
-
-      - name: Create Latest release
-        id: create_latest_release
-        uses: ncipollo/release-action@v1
-        if: endsWith(github.ref, 'master')
-        with:
-          allowUpdates: true
-          name: Latest
-          draft: true
-          prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: "./system.json,./sla-industries.zip"
-          tag: latest
+      - name: Validate dist artifacts
+        run: npm run validate:dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: sla-industries Release
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Resolve release version from tag
+        id: get-version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify package.json and system.json versions match
+        run: node scripts/validate-dist.mjs --sync-only
+
+      - name: Verify tag matches system.json version
+        run: |
+          MANIFEST_VERSION=$(node ./.github/workflows/get-version.js)
+          if [ "$MANIFEST_VERSION" != "${{ steps.get-version.outputs.version }}" ]; then
+            echo "Tag version (${{ steps.get-version.outputs.version }}) does not match system.json ($MANIFEST_VERSION)"
+            exit 1
+          fi
+
+      - name: Run unit tests
+        run: npm run test:unit
+
+      - name: Build and package release zip
+        run: npm run package
+
+      - name: Validate dist and zip artifacts
+        run: node scripts/validate-dist.mjs --zip
+
+      - name: Copy manifest for release asset
+        run: cp dist/system.json system.json
+
+      - name: Create Release
+        id: create_versioned_release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          skipIfReleaseExists: true
+          name: Release ${{ steps.get-version.outputs.version }}
+          draft: true
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "./system.json,./sla-industries.zip"
+          tag: ${{ steps.get-version.outputs.version }}
+
+      - name: Create Latest release
+        id: create_latest_release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          name: Latest
+          draft: true
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "./system.json,./sla-industries.zip"
+          tag: latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+* **CI release publishing:** GitHub releases are created when a version tag is pushed (for example `2.6.5`), not on every push to `main`. Main-branch CI still runs unit tests and validates the dist build.
+
 ## [2.6.4] - 2026-06-05
 
 ### Added

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -273,6 +273,21 @@ npm run validate:package # also validate zip layout
 npm run watch       # live SCSS recompile
 ```
 
+### GitHub release
+
+Pushes to `main` run CI only (version sync, unit tests, dist validation). To publish a release:
+
+1. Bump `version` in `package.json` and `system.json`, update `CHANGELOG.md`, and set the `download` URL in `system.json` to the new tag.
+2. Merge to `main`.
+3. Create and push a git tag matching the version (no `v` prefix required; both `2.6.5` and `v2.6.5` are accepted):
+
+```bash
+git tag 2.6.5
+git push origin 2.6.5
+```
+
+The **Release** workflow builds `sla-industries.zip`, validates it, and creates draft GitHub releases for the version tag and `latest`. Publish the draft release when ready; the **Foundry Website Update** workflow runs on `release: published`.
+
 ---
 
 ## Combat Flow (Weapon Attack → Damage → Wounds)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **CI (`main.yml`)** runs on pushes to `main` and on pull requests: version sync check, unit tests, dist build, and dist validation — no GitHub release creation.
- **Release (`release.yml`)** runs when a semver tag is pushed (e.g. `2.6.5` or `v2.6.5`, including pre-release suffixes like `0.13.2-alpha`): verifies the tag matches `system.json`, packages `sla-industries.zip`, and creates draft releases for the version tag and `latest`.
- Documents the tag-based release flow in `DEVELOPER.md`.

## Motivation

Avoid creating or attempting to update GitHub releases on every merge to `main`. Releases are now an explicit step: bump versions on `main`, then push a matching git tag when ready to publish.

## Release workflow (after merge)

```bash
git tag 2.6.5
git push origin 2.6.5
```

The Foundry website update workflow is unchanged — it still runs when a draft release is **published**.

## Test plan

- [x] Unit tests pass locally
- [ ] Merge to main and confirm CI runs without creating a release
- [ ] Push a version tag and confirm `release.yml` builds artifacts and creates draft releases
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b295bb41-cdd9-4ea4-9e26-f15a3e7e6652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b295bb41-cdd9-4ea4-9e26-f15a3e7e6652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

