### PR TITLE
Fix species/package shared skill rank incrementing to 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * **Foundry cloud bootstrap:** `foundry-bootstrap.mjs` confirms world data migration and pre-migration backup dialogs so E2E can launch `sla-test-world` after system version bumps.
 
+## [2.6.9] - 2026-06-06
+
+### Fixed
+
+* **Species/package skill overlap:** Dropping a species and package that share a skill now increments rank by one (e.g. rank 1 → 2) instead of string-concatenating to rank 11. Skill ranks are stored as strings in the data model; `_processDroppedSkills` now coerces before arithmetic.
+
 ## [2.6.8] - 2026-06-06
 
 ### Changed

--- a/module/helpers/items.mjs
+++ b/module/helpers/items.mjs
@@ -25,6 +25,15 @@ export function normalizeEbbHealWoundMode(raw) {
 }
 
 /**
+ * Increments a skill rank stored as a string (SLA StringField).
+ * @param {string|number|null|undefined} rank
+ * @returns {string}
+ */
+export function incrementSkillRank(rank) {
+    return String((Number(rank) || 0) + 1);
+}
+
+/**
  * Prepares and organizes items for display in the actor sheet.
  * @param {Array} items - The actor's items collection.
  * @param {Object} rollData - The actor's roll data for resolving formulas.

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -5,7 +5,7 @@ import { LuckDialog } from "../apps/luck-dialog.mjs";
 import { XPDialog } from "../apps/xp-dialog.mjs";
 import { SlaSimpleContentDialog } from "../apps/sla-simple-dialog.mjs";
 import { calculateRollResult, generateDiceTooltip, createSLARoll } from "../helpers/dice.mjs";
-import { prepareItems, normalizeEbbEffect, normalizeEbbHealWoundMode } from "../helpers/items.mjs";
+import { prepareItems, normalizeEbbEffect, normalizeEbbHealWoundMode, incrementSkillRank } from "../helpers/items.mjs";
 import { getEbbMosDamageBonus } from "../helpers/ebb-mos.mjs";
 import { applyMeleeModifiers, applyRangedModifiers, calculateRangePenalty } from "../helpers/modifiers.mjs";
 import { addActorItemToHotbar } from "../helpers/sla-hotbar.mjs";
@@ -2742,9 +2742,10 @@ export class SlaActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
             );
 
             if (existingSkill) {
-                const currentRank = existingSkill.system?.rank || 0;
-                toUpdate.push({ _id: existingSkill.id, "system.rank": currentRank + 1 });
-                ui.notifications.info(`Upgraded ${existingSkill.name} to Rank ${currentRank + 1}`);
+                const currentRank = Number(existingSkill.system?.rank) || 0;
+                const newRank = incrementSkillRank(currentRank);
+                toUpdate.push({ _id: existingSkill.id, "system.rank": newRank });
+                ui.notifications.info(`Upgraded ${existingSkill.name} to Rank ${newRank}`);
                 continue;
             }
 
@@ -2753,7 +2754,7 @@ export class SlaActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
                 type: "skill",
                 img: skillData.img || "icons/svg/book.svg",
                 system: {
-                    rank: 1,
+                    rank: "1",
                     stat: CONFIG.SLA?.skillStats?.[skillData.name.toLowerCase()]
                         || skillData.stat
                         || skillData.system?.stat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sla-industries",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "description": "CSS compiler for the SLA Industries system",
   "scripts": {
     "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",
@@ -10,7 +10,7 @@
     "validate:dist": "node scripts/validate-dist.mjs",
     "validate:package": "node scripts/validate-dist.mjs --zip",
     "watch": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map --watch",
-    "test:unit": "node --test tests/unit/inventory-stack.test.mjs tests/unit/system-manifest.test.mjs tests/unit/dice.test.mjs tests/unit/chat-wound-options.test.mjs tests/unit/ebb-mos.test.mjs tests/unit/build-dist.test.mjs tests/unit/update-foundry-release.test.mjs",
+    "test:unit": "node --test tests/unit/inventory-stack.test.mjs tests/unit/system-manifest.test.mjs tests/unit/dice.test.mjs tests/unit/chat-wound-options.test.mjs tests/unit/ebb-mos.test.mjs tests/unit/skill-rank.test.mjs tests/unit/build-dist.test.mjs tests/unit/update-foundry-release.test.mjs",
     "test:e2e": "playwright test",
     "test:e2e:regression": "playwright test tests/e2e/regression-sla.spec.js tests/e2e/regression-item-sheets.spec.js",
     "test:e2e:operators": "playwright test tests/e2e/regression-operators.spec.js",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "sla-industries",
   "title": "SLA Industries 2nd Edition",
   "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "compatibility": {
     "minimum": "14",
     "verified": "14.360"
@@ -50,7 +50,7 @@
   ],
   "url": "https://github.com/VacantFanatic/sla-foundry",
   "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.6.8/sla-industries.zip",
+  "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.6.9/sla-industries.zip",
   "packs": [
     {
       "name": "skills",

--- a/tests/unit/skill-rank.test.mjs
+++ b/tests/unit/skill-rank.test.mjs
@@ -1,0 +1,24 @@
+/**
+ * Unit regression tests for skill rank arithmetic (no Foundry runtime).
+ */
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { incrementSkillRank } from "../../module/helpers/items.mjs";
+
+describe("incrementSkillRank", () => {
+    test("increments string ranks numerically (not concatenation)", () => {
+        assert.equal(incrementSkillRank("1"), "2");
+        assert.equal(incrementSkillRank("10"), "11");
+    });
+
+    test("handles missing or invalid ranks as zero", () => {
+        assert.equal(incrementSkillRank(undefined), "1");
+        assert.equal(incrementSkillRank(null), "1");
+        assert.equal(incrementSkillRank(""), "1");
+        assert.equal(incrementSkillRank("abc"), "1");
+    });
+
+    test("accepts numeric input", () => {
+        assert.equal(incrementSkillRank(2), "3");
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a bug where dropping a species and package that share the same skill set the skill rank to **11** instead of incrementing by one (e.g. rank 1 → 2).

## Root cause

Skill ranks are stored as `StringField` values in the data model (`module/data/item.mjs`). When `_processDroppedSkills` found an existing skill from a prior drop, it used:

```js
const currentRank = existingSkill.system?.rank || 0;
"system.rank": currentRank + 1
```

For a rank of `"1"`, JavaScript string concatenation produced `"11"` instead of numeric addition.

## Fix

- Added `incrementSkillRank()` in `module/helpers/items.mjs` to coerce ranks to numbers before incrementing and return a string.
- Updated `_processDroppedSkills` in `module/sheets/actor-sheet.mjs` to use the helper.
- New skills created from species/package drops now use `"1"` for rank consistency.
- Unit tests in `tests/unit/skill-rank.test.mjs`.

## Version

Bumped to **2.6.9** (`system.json`, `package.json`, `CHANGELOG.md`).

## Testing

- `npm run test:unit` — all 29 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29b786d1-7cf1-42e5-80bb-cd75e16f7608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29b786d1-7cf1-42e5-80bb-cd75e16f7608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

