### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: sla-industries CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/VacantFanatic/sla-foundry/security/code-scanning/3](https://github.com/VacantFanatic/sla-foundry/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/main.yml` at the workflow root so it applies to all jobs (including `build`) unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves current functionality (checkout and CI tasks) while enforcing least privilege for `GITHUB_TOKEN`. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
