### PR TITLE
refactor: extract weapon roll orchestration from actor-sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Data model registry:** `module/data/registry.mjs` and `module/data/model-type-keys.mjs` centralize `CONFIG.*.dataModels` registration; unit test asserts parity with `system.json` `documentTypes`.
 - **Derived data helpers:** Pure encumbrance, wound, and penalty calculators in `module/documents/derived/` with unit tests; `BoilerplateActor` delegates to these modules.
 - **Actor roll modules:** `module/sheets/actor/roll-math.mjs` (pure weapon/skill roll math) and `skill-rolls.mjs` (skill roll execution); unit tests for roll math.
+- **Weapon roll extraction:** `module/sheets/actor/weapon-rolls.mjs` handles attack dialog and weapon roll orchestration; additional pure helpers in `roll-math.mjs`.
 
 ### Changed
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -43,7 +43,8 @@ sla-industries/
 │   └── sheets/
 │       ├── actor/
 │       │   ├── roll-math.mjs   # Pure skill/weapon roll math (unit tested)
-│       │   └── skill-rolls.mjs # Skill roll execution extracted from actor sheet
+│       │   ├── skill-rolls.mjs # Skill roll execution extracted from actor sheet
+│       │   └── weapon-rolls.mjs # Weapon attack dialog and roll orchestration
 │       ├── actor-sheet.mjs     # SlaActorSheet (operative/character, ApplicationV2)
 │       ├── actor-npc-sheet.mjs # SlaNPCSheet (threat/NPC, ApplicationV2)
 │       ├── actor-vehicle-sheet.mjs  # SlaVehicleSheet (vehicle, ApplicationV2)

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -11,15 +11,16 @@ import { applyMeleeModifiers, applyRangedModifiers, calculateRangePenalty } from
 import { addActorItemToHotbar } from '../helpers/sla-hotbar.mjs';
 import { SLAChat } from '../helpers/chat.mjs';
 import { syncEbbCriticalFlux } from '../helpers/ebb-flux.mjs';
-import { shouldShowMosWoundChoice } from '../helpers/wound-visibility.mjs';
 import { handleStackableActorItemDrop } from '../helpers/inventory-stack.mjs';
 import {
+    applySuccessThroughExperience,
+    buildSkillDiceResults,
     buildWeaponDamageFormula,
-    buildWeaponRollMods,
-    readWeaponRollFormState,
-    resolveWeaponMosOutcome
+    computeMeleeStrDamageModifier,
+    computeSuccessDieOutcome
 } from './actor/roll-math.mjs';
 import { executeSkillRollFromItem } from './actor/skill-rolls.mjs';
+import { processWeaponRoll, renderAttackDialog } from './actor/weapon-rolls.mjs';
 
 const { HandlebarsApplicationMixin } = foundry.applications.api;
 const { ActorSheetV2 } = foundry.applications.sheets;
@@ -1190,11 +1191,7 @@ export class SlaActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
         if (item.type === 'weapon') {
             const isMelee = (item.system.attackType || 'melee') === 'melee';
-            if (isMelee) {
-                if (strValue >= 7) damageMod += 4;
-                else if (strValue === 6) damageMod += 2;
-                else if (strValue === 5) damageMod += 1;
-            }
+            if (isMelee) damageMod += computeMeleeStrDamageModifier(strValue);
             damageMod += this._getAmmoDamageModifierForWeapon(item);
         }
 
@@ -1260,69 +1257,7 @@ export class SlaActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
 
     // --- DIALOG ---
     async _renderAttackDialog(item, isMelee) {
-        if (!this._canProceedWithWeaponAttack(item, { requireTarget: true })) return;
-
-        // 1. Prepare Firing Modes (Ranged Only)
-        let validModes = {};
-        let defaultModeKey = '';
-
-        if (!isMelee && item.system.firingModes) {
-            // Filter down to only active modes
-            validModes = Object.entries(item.system.firingModes)
-                .filter(([key, data]) => data.active)
-                .reduce((obj, [key, data]) => {
-                    obj[key] = data; // Keep the full data object so we can read recoil later
-                    return obj;
-                }, {});
-
-            // Safety Fallback: If no modes active, default to Single
-            if (Object.keys(validModes).length === 0) {
-                validModes['single'] = { label: 'Single', active: true, rounds: 1, recoil: 0 };
-            }
-
-            // Pick the first valid mode as the default selection
-            defaultModeKey = Object.keys(validModes)[0];
-        }
-
-        // --- RANGE CALCULATION ---
-        const { rangePenaltyMsg } = this._resolveRangedAttackContext(item, isMelee);
-        // -------------------------
-
-        // 2. Prepare Template Data
-        const templateData = {
-            item: item,
-            isMelee: isMelee,
-            validModes: validModes,
-            selectedMode: defaultModeKey, // Pass this to HBS for the <select>
-            rangePenaltyMsg: rangePenaltyMsg, // Display logic inside template might be needed, or we just rely on implicit knowledge for now?
-            // Actually, we should probably Pass 'isLongRange' to the process function via a hidden field or reconstruct it,
-            // BUT simpler to just reconstruct it in _processWeaponRoll since we enforce target selection now.
-
-            // Melee uses item recoil (usually 0), Ranged uses the recoil of the default mode
-            recoil: isMelee ? item.system.recoil || 0 : validModes[defaultModeKey]?.recoil || 0,
-
-            // AIM DATA
-            canAim: ['pistol', 'rifle'].includes((item.system.skill || '').toLowerCase()),
-            aimLimit: (() => {
-                const sKey = (item.system.skill || '').toLowerCase();
-                const sItem = this.actor.items.find((i) => i.type === 'skill' && i.name.toLowerCase() === sKey);
-                return sItem ? sItem.system.rank || 0 : 0;
-            })()
-        };
-
-        const content = await foundry.applications.handlebars.renderTemplate(
-            'systems/sla-industries/templates/dialogs/attack-dialog.hbs',
-            templateData
-        );
-
-        await new SlaSimpleContentDialog({
-            title: `Attack: ${item.name} ${rangePenaltyMsg}`,
-            contentHtml: content,
-            width: 520,
-            classes: ['sla-dialog-window', 'dialog'],
-            actionLabel: 'ROLL',
-            onConfirm: (root) => void this._processWeaponRoll(item, root, isMelee)
-        }).render(true);
+        return renderAttackDialog(this, item, isMelee);
     }
 
     async _executeSkillRoll(element) {
@@ -1390,407 +1325,23 @@ export class SlaActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         }
     }
 
-    _buildWeaponRollTemplateData({
-        item,
-        roll,
-        baseModifier,
-        notesText,
-        successDieModifier,
-        resultColor,
-        sdTotal,
-        skillDiceData,
-        showDamageButton,
-        finalDamageFormula,
-        adValue,
-        rofRerollSD,
-        isSuccess,
-        skillSuccessCount,
-        mosEffectText,
-        mosChoiceData
-    }) {
-        const targetActorType = game.user.targets.first()?.actor?.type;
-        const showWoundChoice = shouldShowMosWoundChoice({
-            hasChoice: Boolean(mosChoiceData?.hasChoice),
-            targetActorType,
-            enableNpcWoundTracking: game.settings.get('sla-industries', 'enableNPCWoundTracking')
-        });
-
-        return {
-            actorUuid: this.actor.uuid,
-            borderColor: resultColor,
-            headerColor: resultColor,
-            resultColor: resultColor,
-            itemName: item.name.toUpperCase(),
-            successTotal: sdTotal,
-            tooltip: this._generateTooltip(roll, baseModifier, successDieModifier),
-            skillDice: skillDiceData,
-            notes: notesText,
-            showDamageButton: showDamageButton,
-            dmgFormula: finalDamageFormula,
-            dmgDisplay: this._resolveDamageDisplay(finalDamageFormula),
-            minDamage: Number(item.system.minDamage) || 0,
-            adValue: adValue,
-            sdIsReroll: rofRerollSD,
-            mos: {
-                isSuccess: isSuccess,
-                hits: skillSuccessCount,
-                effect: mosEffectText,
-                ...mosChoiceData,
-                showWoundChoice
-            },
-            canUseLuck: this.actor.system.stats.luck.value > 0,
-            luckValue: this.actor.system.stats.luck.value,
-            luckSpent: false,
-            isWeapon: true
-        };
-    }
-
-    async _rerollDieKeepHighest(currentResult) {
-        const newRoll = createSLARoll('1d10');
-        await newRoll.evaluate();
-        const newResult = newRoll.terms[0].results[0].result;
-        if (newResult > currentResult) {
-            return { result: newResult, rerolled: true };
-        }
-        return { result: currentResult, rerolled: false };
-    }
-
-    async _applyWeaponRofRerolls({ roll, flags, notes }) {
-        let rofRerollSD = false;
-        let rofRerollSkills = [];
-
-        if (flags.rerollSD || flags.rerollAll) {
-            const sdTerm = roll.terms[0];
-            const oldValue = sdTerm.results[0].result;
-            const outcome = await this._rerollDieKeepHighest(oldValue);
-
-            rofRerollSD = true;
-            if (outcome.rerolled) {
-                sdTerm.results[0].result = outcome.result;
-                notes.push(`<strong>ROF:</strong> Success Die Improved (${oldValue} ➔ ${outcome.result})`);
-            } else {
-                notes.push(`<strong>ROF:</strong> Success Die Kept (${oldValue})`);
-            }
-        }
-
-        if (flags.rerollAll && roll.terms.length > 2) {
-            const skillTerm = roll.terms[2];
-            let improvedCount = 0;
-
-            for (let i = 0; i < skillTerm.results.length; i++) {
-                const oldValue = skillTerm.results[i].result;
-                const outcome = await this._rerollDieKeepHighest(oldValue);
-                rofRerollSkills.push(i);
-
-                if (outcome.rerolled) {
-                    skillTerm.results[i].result = outcome.result;
-                    improvedCount++;
-                }
-            }
-
-            if (improvedCount > 0) {
-                notes.push(`<strong>ROF:</strong> ${improvedCount} Skill Dice Improved.`);
-            } else {
-                notes.push(`<strong>ROF:</strong> Skill Dice Kept.`);
-            }
-        }
-
-        if (rofRerollSD || rofRerollSkills.length > 0) {
-            roll._total = roll._evaluateTotal();
-        }
-
-        return { rofRerollSD, rofRerollSkills };
-    }
-
-    _buildSkillDiceResults({
-        roll,
-        baseModifier,
-        targetNumber,
-        autoSuccesses = 0,
-        rerollIndexes = [],
-        includeRerollFlag = false
-    }) {
-        const rerollIndexSet = new Set(rerollIndexes);
-        const skillDiceData = [];
-        let skillSuccessCount = 0;
-
-        if (roll.terms.length > 2) {
-            roll.terms[2].results.forEach((result, index) => {
-                const total = result.result + baseModifier;
-                const isHit = total >= targetNumber;
-                if (isHit) skillSuccessCount++;
-
-                const dieData = {
-                    raw: result.result,
-                    total: total,
-                    borderColor: isHit ? '#39ff14' : '#555',
-                    textColor: isHit ? '#39ff14' : '#ccc'
-                };
-                if (includeRerollFlag) {
-                    dieData.isReroll = rerollIndexSet.has(index);
-                }
-                skillDiceData.push(dieData);
-            });
-        }
-
-        skillSuccessCount += autoSuccesses;
-        for (let i = 0; i < autoSuccesses; i++) {
-            skillDiceData.push({ raw: '-', total: 'Auto', borderColor: '#39ff14', textColor: '#39ff14' });
-        }
-
-        return { skillDiceData, skillSuccessCount };
+    _buildSkillDiceResults(params) {
+        return buildSkillDiceResults(params);
     }
 
     _computeSuccessDieOutcome({ roll, baseModifier, successDieModifier = 0, targetNumber }) {
         const sdRaw = roll.terms[0].results[0].result;
-        const sdTotal = sdRaw + baseModifier + successDieModifier;
-        const isBaseSuccess = sdTotal >= targetNumber;
-        return { sdRaw, sdTotal, isBaseSuccess };
+        return computeSuccessDieOutcome({ sdRaw, baseModifier, successDieModifier, targetNumber });
     }
 
     _applySuccessThroughExperience({ isBaseSuccess, skillSuccessCount, threshold = 4, notes }) {
-        let isSuccess = isBaseSuccess;
-        let successThroughExperience = false;
-
-        if (!isBaseSuccess && skillSuccessCount >= threshold) {
-            isSuccess = true;
-            successThroughExperience = true;
-            if (notes) {
-                notes.push('<strong>Success Through Experience</strong> (4+ Skill Dice hit).');
-            }
-        }
-
-        return { isSuccess, successThroughExperience };
+        const result = applySuccessThroughExperience({ isBaseSuccess, skillSuccessCount, threshold });
+        if (result.note && notes) notes.push(result.note);
+        return { isSuccess: result.isSuccess, successThroughExperience: result.successThroughExperience };
     }
 
     async _processWeaponRoll(item, html, isMelee) {
-        const root = html?.jquery ? html[0] : html;
-        const form = root instanceof HTMLFormElement ? root : root?.querySelector?.('form');
-        if (!form) return;
-
-        const weapon = this.actor.items.get(item.id) ?? item;
-        if (!this._canProceedWithWeaponAttack(weapon, { requireTarget: true })) return;
-        item = weapon;
-
-        // 1. SETUP
-        // Melee weapons use STR, ranged weapons use DEX.
-        const statKey = isMelee ? 'str' : 'dex';
-        const statValue = this.actor.system.stats[statKey]?.total ?? this.actor.system.stats[statKey]?.value ?? 0;
-        const strValue = Number(this.actor.system.stats.str?.total ?? this.actor.system.stats.str?.value ?? 0);
-        const rank = this._resolveCombatSkillRank(item.system.skill);
-        const formState = readWeaponRollFormState(form);
-        let mods = buildWeaponRollMods(formState);
-
-        let notes = [];
-        let flags = { rerollSD: false, rerollAll: false };
-
-        // AIM VALIDATION
-        const totalAim = mods.aimSd + mods.aimAuto;
-        if (totalAim > rank) {
-            ui.notifications.warn(`Total Aiming rounds (${totalAim}) cannot exceed Skill Rank (${rank}).`);
-            return;
-        }
-
-        // Conditions
-        if (this.actor.system.conditions?.prone) mods.allDice -= 1;
-        if (this.actor.system.conditions?.stunned) mods.allDice -= 1;
-
-        // --- AIM BONUSES ---
-        if (mods.aimSd > 0) mods.successDie += mods.aimSd;
-        if (mods.aimAuto > 0) mods.autoSkillSuccesses += mods.aimAuto;
-
-        // --- RANGE PENALTY LOGIC ---
-        const rangedContext = this._resolveRangedAttackContext(item, isMelee);
-        // ---------------------------
-
-        // Apply Modifiers
-        if (isMelee) {
-            this._applyMeleeModifiers(form, strValue, mods);
-
-            // --- DEFENSE MODIFIERS (Melee) - Note: applied in _applyMeleeModifiers ---
-            // Add notes for display (modifiers already applied in helper)
-            if (mods.combatDef > 0) {
-                notes.push(`Defended (Combat Def: -${mods.combatDef})`);
-            }
-            if (mods.acroDef > 0) {
-                const pen = mods.acroDef * 2;
-                notes.push(`Defended (Acrobatics: -${pen})`);
-            }
-            if (mods.targetProne) {
-                mods.successDie += 2;
-                notes.push(`Target Prone (+2 SD)`);
-            }
-            // ---------------------------------
-
-            // Clamp reserved dice to available rank.
-            if (mods.reservedDice > rank) {
-                ui.notifications.warn(
-                    `Cannot reserve more dice (${mods.reservedDice}) than Skill Rank (${rank}). Reduced to ${rank}.`
-                );
-                mods.reservedDice = rank;
-            }
-            if (mods.reservedDice > 0) {
-                notes.push(`Reserved ${mods.reservedDice} Dice.`);
-            }
-            // -------------------------------------------
-        } else {
-            // Check for false return to stop execution
-            const canFire = await this._applyRangedModifiers(item, form, mods, notes, flags, {
-                forceLongRange: rangedContext.isLongRange
-            });
-            if (canFire === false) return;
-        }
-
-        const penalty = this.actor.system.wounds.penalty || 0;
-        if (game.settings.get('sla-industries', 'enableAutomaticWoundPenalties')) {
-            mods.allDice -= penalty;
-        }
-
-        // Powersuit attacks apply their built-in attack penalty automatically.
-        if (item.system.powersuitAttack) {
-            const attackPenalty = Number(item.system.attackPenalty) || 0;
-            if (attackPenalty !== 0) {
-                mods.allDice += attackPenalty;
-                if (attackPenalty < 0) notes.push(`Powersuit Attack (${attackPenalty})`);
-                else notes.push(`Powersuit Attack (+${attackPenalty})`);
-            }
-        }
-
-        // 4. ROLL
-        // Base modifier excludes success-die-only modifiers (aim/target prone).
-        const baseModifier = statValue + rank + mods.allDice;
-
-        // 5. CALCULATE SUCCESS
-        let skillDiceCount = rank + 1 + (mods.rank || 0) - (mods.reservedDice || 0) - (mods.aimAuto || 0);
-        if (skillDiceCount < 0) skillDiceCount = 0;
-
-        const rollFormula = `1d10 + ${skillDiceCount}d10`;
-        let roll = createSLARoll(rollFormula);
-        await roll.evaluate();
-
-        // We pass the final Base Mod and Success Die Mod
-        // TN (Target Number) is 10 for all weapon attacks (melee and ranged)
-        const TN = 10;
-        const result = calculateRollResult(roll, baseModifier, TN, {
-            autoSkillSuccesses: mods.aimAuto || 0,
-            successDieModifier: mods.successDie // Pass explicit SD mod
-        });
-
-        const { rofRerollSD, rofRerollSkills } = await this._applyWeaponRofRerolls({
-            roll,
-            flags,
-            notes
-        });
-
-        const { sdTotal, isBaseSuccess } = this._computeSuccessDieOutcome({
-            roll,
-            baseModifier,
-            successDieModifier: mods.successDie,
-            targetNumber: TN
-        });
-
-        const { skillDiceData, skillSuccessCount } = this._buildSkillDiceResults({
-            roll,
-            baseModifier,
-            targetNumber: TN,
-            autoSuccesses: mods.autoSkillSuccesses,
-            rerollIndexes: rofRerollSkills,
-            includeRerollFlag: true
-        });
-
-        const { isSuccess, successThroughExperience } = this._applySuccessThroughExperience({
-            isBaseSuccess,
-            skillSuccessCount,
-            threshold: 4,
-            notes
-        });
-
-        // Update Result Color if it became a success
-        const resultColor = isSuccess ? '#39ff14' : '#f55';
-
-        const { mosDamageBonus, mosEffectText, mosChoiceData, shouldApplyHeadWound } = resolveWeaponMosOutcome({
-            isSuccess,
-            successThroughExperience,
-            skillSuccessCount
-        });
-        if (shouldApplyHeadWound) {
-            await this._applyHeadshotSideEffect(notes);
-        }
-
-        // Damage Calculation
-        // Note: If user has a choice, we DO NOT add the bonus yet. They must click the button.
-        let rawBase = item.system.damage || item.system.dmg || '0';
-        let baseDmg = String(rawBase);
-        let totalMod = mods.damage + mosDamageBonus;
-
-        const finalDmgFormula = buildWeaponDamageFormula(baseDmg, totalMod);
-        let resolvedPreview = null;
-        try {
-            const replaced = Roll.replaceFormulaData(finalDmgFormula, this.actor.getRollData());
-            resolvedPreview = Math.round(Number(Function('"use strict";return (' + replaced + ')')()));
-        } catch (_err) {
-            resolvedPreview = null;
-        }
-
-        let showButton = isSuccess && finalDmgFormula && finalDmgFormula !== '0';
-
-        // 1. CAPTURE AD VALUE (Ensure it's a number)
-        let adValue = Number(item.system.ad) || 0;
-        if (item.system.powersuitAttack) {
-            const adFromStrMinus = Number(item.system.adFromStrMinus) || 0;
-            if (adFromStrMinus > 0) {
-                adValue = Math.max(0, strValue - adFromStrMinus);
-            }
-        }
-
-        const notesText = notes.join(' ');
-        const templateData = this._buildWeaponRollTemplateData({
-            item,
-            roll,
-            baseModifier,
-            notesText,
-            successDieModifier: mods.successDie,
-            resultColor,
-            sdTotal,
-            skillDiceData,
-            showDamageButton: showButton,
-            finalDamageFormula: finalDmgFormula,
-            adValue,
-            rofRerollSD,
-            isSuccess,
-            skillSuccessCount,
-            mosEffectText,
-            mosChoiceData
-        });
-
-        const chatContent = await foundry.applications.handlebars.renderTemplate(
-            'systems/sla-industries/templates/chat/chat-weapon-rolls.hbs',
-            templateData
-        );
-
-        roll.toMessage({
-            speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-            content: chatContent,
-            flags: {
-                sla: this._buildSlaRollFlags({
-                    baseModifier: baseModifier,
-                    itemName: item.name.toUpperCase(),
-                    notes: notesText,
-                    tn: TN,
-                    extra: {
-                        rofRerollSD: rofRerollSD,
-                        rofRerollSkills: rofRerollSkills,
-                        targets: Array.from(game.user.targets).map((t) => t.document.uuid),
-                        damageBase: baseDmg,
-                        damageMod: mods.damage,
-                        adValue: adValue,
-                        autoSkillSuccesses: mods.autoSkillSuccesses,
-                        successDieModifier: mods.successDie,
-                        isWeapon: true
-                    }
-                })
-            }
-        });
+        return processWeaponRoll(this, item, html, isMelee);
     }
 
     // --- EXPLOSIVE LOGIC ---

--- a/module/sheets/actor/roll-math.mjs
+++ b/module/sheets/actor/roll-math.mjs
@@ -95,3 +95,114 @@ export function resolveWeaponMosOutcome({ isSuccess, successThroughExperience, s
 
     return { mosDamageBonus, mosEffectText, mosChoiceData, shouldApplyHeadWound };
 }
+
+/**
+ * @param {number} strValue
+ * @returns {number}
+ */
+export function computeMeleeStrDamageModifier(strValue) {
+    const str = Number(strValue) || 0;
+    if (str >= 7) return 4;
+    if (str === 6) return 2;
+    if (str === 5) return 1;
+    return 0;
+}
+
+/**
+ * @param {{ sdRaw: number, baseModifier: number, successDieModifier?: number, targetNumber: number }}
+ */
+export function computeSuccessDieOutcome({ sdRaw, baseModifier, successDieModifier = 0, targetNumber }) {
+    const sdTotal = sdRaw + baseModifier + successDieModifier;
+    return { sdRaw, sdTotal, isBaseSuccess: sdTotal >= targetNumber };
+}
+
+/**
+ * @param {{ isBaseSuccess: boolean, skillSuccessCount: number, threshold?: number }}
+ */
+export function applySuccessThroughExperience({ isBaseSuccess, skillSuccessCount, threshold = 4 }) {
+    let isSuccess = isBaseSuccess;
+    let successThroughExperience = false;
+    let note = null;
+
+    if (!isBaseSuccess && skillSuccessCount >= threshold) {
+        isSuccess = true;
+        successThroughExperience = true;
+        note = '<strong>Success Through Experience</strong> (4+ Skill Dice hit).';
+    }
+
+    return { isSuccess, successThroughExperience, note };
+}
+
+/**
+ * @param {{ roll: { terms: Array<{ results?: Array<{ result: number }> }> }, baseModifier: number, targetNumber: number, autoSuccesses?: number, rerollIndexes?: number[], includeRerollFlag?: boolean }}
+ */
+export function buildSkillDiceResults({
+    roll,
+    baseModifier,
+    targetNumber,
+    autoSuccesses = 0,
+    rerollIndexes = [],
+    includeRerollFlag = false
+}) {
+    const rerollIndexSet = new Set(rerollIndexes);
+    const skillDiceData = [];
+    let skillSuccessCount = 0;
+
+    if (roll.terms.length > 2 && roll.terms[2].results) {
+        roll.terms[2].results.forEach((result, index) => {
+            const total = result.result + baseModifier;
+            const isHit = total >= targetNumber;
+            if (isHit) skillSuccessCount++;
+
+            const dieData = {
+                raw: result.result,
+                total: total,
+                borderColor: isHit ? '#39ff14' : '#555',
+                textColor: isHit ? '#39ff14' : '#ccc'
+            };
+            if (includeRerollFlag) {
+                dieData.isReroll = rerollIndexSet.has(index);
+            }
+            skillDiceData.push(dieData);
+        });
+    }
+
+    skillSuccessCount += autoSuccesses;
+    for (let i = 0; i < autoSuccesses; i++) {
+        skillDiceData.push({ raw: '-', total: 'Auto', borderColor: '#39ff14', textColor: '#39ff14' });
+    }
+
+    return { skillDiceData, skillSuccessCount };
+}
+
+/**
+ * @param {number} rank
+ * @param {{ rank?: number, reservedDice?: number, aimAuto?: number }} mods
+ * @returns {number}
+ */
+export function computeWeaponSkillDiceCount(rank, mods = {}) {
+    let count = rank + 1 + (mods.rank || 0) - (mods.reservedDice || 0) - (mods.aimAuto || 0);
+    return Math.max(0, count);
+}
+
+/**
+ * @param {HTMLFormElement} form
+ */
+export function readExplosiveRollForm(form) {
+    return {
+        mod: Number(form.modifier?.value) || 0,
+        cover: Number(form.cover?.value) || 0,
+        aiming: form.aiming?.value || 'none',
+        blind: form.blind?.checked || false
+    };
+}
+
+/**
+ * @param {{ blastRadiusInner?: number, blastRadiusOuter?: number }} itemSystem
+ */
+export function resolveExplosiveBlastData(itemSystem) {
+    const innerDist = itemSystem.blastRadiusInner || 0;
+    let outerDist = itemSystem.blastRadiusOuter || 0;
+    if (outerDist === 0) outerDist = 5;
+    return { innerDist, outerDist };
+}

--- a/module/sheets/actor/weapon-rolls.mjs
+++ b/module/sheets/actor/weapon-rolls.mjs
@@ -1,0 +1,386 @@
+import { SlaSimpleContentDialog } from '../../apps/sla-simple-dialog.mjs';
+import { calculateRollResult, createSLARoll, generateDiceTooltip } from '../../helpers/dice.mjs';
+import { shouldShowMosWoundChoice } from '../../helpers/wound-visibility.mjs';
+import {
+    applySuccessThroughExperience,
+    buildSkillDiceResults,
+    buildWeaponDamageFormula,
+    buildWeaponRollMods,
+    computeSuccessDieOutcome,
+    computeWeaponSkillDiceCount,
+    readWeaponRollFormState,
+    resolveWeaponMosOutcome
+} from './roll-math.mjs';
+
+async function rerollDieKeepHighest(currentResult) {
+    const newRoll = createSLARoll('1d10');
+    await newRoll.evaluate();
+    const newResult = newRoll.terms[0].results[0].result;
+    if (newResult > currentResult) {
+        return { result: newResult, rerolled: true };
+    }
+    return { result: currentResult, rerolled: false };
+}
+
+/**
+ * @param {{ roll: Roll, flags: { rerollSD?: boolean, rerollAll?: boolean }, notes: string[] }}
+ */
+async function applyWeaponRofRerolls({ roll, flags, notes }) {
+    let rofRerollSD = false;
+    const rofRerollSkills = [];
+
+    if (flags.rerollSD || flags.rerollAll) {
+        const sdTerm = roll.terms[0];
+        const oldValue = sdTerm.results[0].result;
+        const outcome = await rerollDieKeepHighest(oldValue);
+
+        rofRerollSD = true;
+        if (outcome.rerolled) {
+            sdTerm.results[0].result = outcome.result;
+            notes.push(`<strong>ROF:</strong> Success Die Improved (${oldValue} ➔ ${outcome.result})`);
+        } else {
+            notes.push(`<strong>ROF:</strong> Success Die Kept (${oldValue})`);
+        }
+    }
+
+    if (flags.rerollAll && roll.terms.length > 2) {
+        const skillTerm = roll.terms[2];
+        let improvedCount = 0;
+
+        for (let i = 0; i < skillTerm.results.length; i++) {
+            const oldValue = skillTerm.results[i].result;
+            const outcome = await rerollDieKeepHighest(oldValue);
+            rofRerollSkills.push(i);
+
+            if (outcome.rerolled) {
+                skillTerm.results[i].result = outcome.result;
+                improvedCount++;
+            }
+        }
+
+        if (improvedCount > 0) {
+            notes.push(`<strong>ROF:</strong> ${improvedCount} Skill Dice Improved.`);
+        } else {
+            notes.push(`<strong>ROF:</strong> Skill Dice Kept.`);
+        }
+    }
+
+    if (rofRerollSD || rofRerollSkills.length > 0) {
+        roll._total = roll._evaluateTotal();
+    }
+
+    return { rofRerollSD, rofRerollSkills };
+}
+
+/**
+ * @param {import('../actor-sheet.mjs').SlaActorSheet} sheet
+ */
+function buildWeaponRollTemplateData(
+    sheet,
+    {
+        item,
+        roll,
+        baseModifier,
+        notesText,
+        successDieModifier,
+        resultColor,
+        sdTotal,
+        skillDiceData,
+        showDamageButton,
+        finalDamageFormula,
+        adValue,
+        rofRerollSD,
+        isSuccess,
+        skillSuccessCount,
+        mosEffectText,
+        mosChoiceData
+    }
+) {
+    const targetActorType = game.user.targets.first()?.actor?.type;
+    const showWoundChoice = shouldShowMosWoundChoice({
+        hasChoice: Boolean(mosChoiceData?.hasChoice),
+        targetActorType,
+        enableNpcWoundTracking: game.settings.get('sla-industries', 'enableNPCWoundTracking')
+    });
+
+    return {
+        actorUuid: sheet.actor.uuid,
+        borderColor: resultColor,
+        headerColor: resultColor,
+        resultColor: resultColor,
+        itemName: item.name.toUpperCase(),
+        successTotal: sdTotal,
+        tooltip: generateDiceTooltip(roll, baseModifier, 0, successDieModifier),
+        skillDice: skillDiceData,
+        notes: notesText,
+        showDamageButton: showDamageButton,
+        dmgFormula: finalDamageFormula,
+        dmgDisplay: sheet._resolveDamageDisplay(finalDamageFormula),
+        minDamage: Number(item.system.minDamage) || 0,
+        adValue: adValue,
+        sdIsReroll: rofRerollSD,
+        mos: {
+            isSuccess: isSuccess,
+            hits: skillSuccessCount,
+            effect: mosEffectText,
+            ...mosChoiceData,
+            showWoundChoice
+        },
+        canUseLuck: sheet.actor.system.stats.luck.value > 0,
+        luckValue: sheet.actor.system.stats.luck.value,
+        luckSpent: false,
+        isWeapon: true
+    };
+}
+
+/**
+ * @param {import('../actor-sheet.mjs').SlaActorSheet} sheet
+ * @param {Item} item
+ * @param {boolean} isMelee
+ */
+export async function renderAttackDialog(sheet, item, isMelee) {
+    if (!sheet._canProceedWithWeaponAttack(item, { requireTarget: true })) return;
+
+    let validModes = {};
+    let defaultModeKey = '';
+
+    if (!isMelee && item.system.firingModes) {
+        validModes = Object.entries(item.system.firingModes)
+            .filter(([, data]) => data.active)
+            .reduce((obj, [key, data]) => {
+                obj[key] = data;
+                return obj;
+            }, {});
+
+        if (Object.keys(validModes).length === 0) {
+            validModes['single'] = { label: 'Single', active: true, rounds: 1, recoil: 0 };
+        }
+
+        defaultModeKey = Object.keys(validModes)[0];
+    }
+
+    const { rangePenaltyMsg } = sheet._resolveRangedAttackContext(item, isMelee);
+
+    const templateData = {
+        item: item,
+        isMelee: isMelee,
+        validModes: validModes,
+        selectedMode: defaultModeKey,
+        rangePenaltyMsg: rangePenaltyMsg,
+        recoil: isMelee ? item.system.recoil || 0 : validModes[defaultModeKey]?.recoil || 0,
+        canAim: ['pistol', 'rifle'].includes((item.system.skill || '').toLowerCase()),
+        aimLimit: (() => {
+            const sKey = (item.system.skill || '').toLowerCase();
+            const sItem = sheet.actor.items.find((i) => i.type === 'skill' && i.name.toLowerCase() === sKey);
+            return sItem ? sItem.system.rank || 0 : 0;
+        })()
+    };
+
+    const content = await foundry.applications.handlebars.renderTemplate(
+        'systems/sla-industries/templates/dialogs/attack-dialog.hbs',
+        templateData
+    );
+
+    await new SlaSimpleContentDialog({
+        title: `Attack: ${item.name} ${rangePenaltyMsg}`,
+        contentHtml: content,
+        width: 520,
+        classes: ['sla-dialog-window', 'dialog'],
+        actionLabel: 'ROLL',
+        onConfirm: (root) => void processWeaponRoll(sheet, item, root, isMelee)
+    }).render(true);
+}
+
+/**
+ * @param {import('../actor-sheet.mjs').SlaActorSheet} sheet
+ * @param {Item} item
+ * @param {HTMLElement | HTMLFormElement} html
+ * @param {boolean} isMelee
+ */
+export async function processWeaponRoll(sheet, item, html, isMelee) {
+    const root = html?.jquery ? html[0] : html;
+    const form = root instanceof HTMLFormElement ? root : root?.querySelector?.('form');
+    if (!form) return;
+
+    const weapon = sheet.actor.items.get(item.id) ?? item;
+    if (!sheet._canProceedWithWeaponAttack(weapon, { requireTarget: true })) return;
+    item = weapon;
+
+    const statKey = isMelee ? 'str' : 'dex';
+    const statValue = sheet.actor.system.stats[statKey]?.total ?? sheet.actor.system.stats[statKey]?.value ?? 0;
+    const strValue = Number(sheet.actor.system.stats.str?.total ?? sheet.actor.system.stats.str?.value ?? 0);
+    const rank = sheet._resolveCombatSkillRank(item.system.skill);
+    const formState = readWeaponRollFormState(form);
+    const mods = buildWeaponRollMods(formState);
+
+    const notes = [];
+    const flags = { rerollSD: false, rerollAll: false };
+
+    const totalAim = mods.aimSd + mods.aimAuto;
+    if (totalAim > rank) {
+        ui.notifications.warn(`Total Aiming rounds (${totalAim}) cannot exceed Skill Rank (${rank}).`);
+        return;
+    }
+
+    if (sheet.actor.system.conditions?.prone) mods.allDice -= 1;
+    if (sheet.actor.system.conditions?.stunned) mods.allDice -= 1;
+
+    if (mods.aimSd > 0) mods.successDie += mods.aimSd;
+    if (mods.aimAuto > 0) mods.autoSkillSuccesses += mods.aimAuto;
+
+    const rangedContext = sheet._resolveRangedAttackContext(item, isMelee);
+
+    if (isMelee) {
+        sheet._applyMeleeModifiers(form, strValue, mods);
+
+        if (mods.combatDef > 0) {
+            notes.push(`Defended (Combat Def: -${mods.combatDef})`);
+        }
+        if (mods.acroDef > 0) {
+            const pen = mods.acroDef * 2;
+            notes.push(`Defended (Acrobatics: -${pen})`);
+        }
+        if (mods.targetProne) {
+            mods.successDie += 2;
+            notes.push(`Target Prone (+2 SD)`);
+        }
+
+        if (mods.reservedDice > rank) {
+            ui.notifications.warn(
+                `Cannot reserve more dice (${mods.reservedDice}) than Skill Rank (${rank}). Reduced to ${rank}.`
+            );
+            mods.reservedDice = rank;
+        }
+        if (mods.reservedDice > 0) {
+            notes.push(`Reserved ${mods.reservedDice} Dice.`);
+        }
+    } else {
+        const canFire = await sheet._applyRangedModifiers(item, form, mods, notes, flags, {
+            forceLongRange: rangedContext.isLongRange
+        });
+        if (canFire === false) return;
+    }
+
+    const penalty = sheet.actor.system.wounds.penalty || 0;
+    if (game.settings.get('sla-industries', 'enableAutomaticWoundPenalties')) {
+        mods.allDice -= penalty;
+    }
+
+    if (item.system.powersuitAttack) {
+        const attackPenalty = Number(item.system.attackPenalty) || 0;
+        if (attackPenalty !== 0) {
+            mods.allDice += attackPenalty;
+            if (attackPenalty < 0) notes.push(`Powersuit Attack (${attackPenalty})`);
+            else notes.push(`Powersuit Attack (+${attackPenalty})`);
+        }
+    }
+
+    const baseModifier = statValue + rank + mods.allDice;
+    const skillDiceCount = computeWeaponSkillDiceCount(rank, mods);
+    const rollFormula = `1d10 + ${skillDiceCount}d10`;
+    const roll = createSLARoll(rollFormula);
+    await roll.evaluate();
+
+    const TN = 10;
+    calculateRollResult(roll, baseModifier, TN, {
+        autoSkillSuccesses: mods.aimAuto || 0,
+        successDieModifier: mods.successDie
+    });
+
+    const { rofRerollSD, rofRerollSkills } = await applyWeaponRofRerolls({ roll, flags, notes });
+
+    const sdRaw = roll.terms[0].results[0].result;
+    const { sdTotal, isBaseSuccess } = computeSuccessDieOutcome({
+        sdRaw,
+        baseModifier,
+        successDieModifier: mods.successDie,
+        targetNumber: TN
+    });
+
+    const { skillDiceData, skillSuccessCount } = buildSkillDiceResults({
+        roll,
+        baseModifier,
+        targetNumber: TN,
+        autoSuccesses: mods.autoSkillSuccesses,
+        rerollIndexes: rofRerollSkills,
+        includeRerollFlag: true
+    });
+
+    const ste = applySuccessThroughExperience({ isBaseSuccess, skillSuccessCount, threshold: 4 });
+    if (ste.note) notes.push(ste.note);
+
+    const isSuccess = ste.isSuccess;
+    const successThroughExperience = ste.successThroughExperience;
+    const resultColor = isSuccess ? '#39ff14' : '#f55';
+
+    const { mosDamageBonus, mosEffectText, mosChoiceData, shouldApplyHeadWound } = resolveWeaponMosOutcome({
+        isSuccess,
+        successThroughExperience,
+        skillSuccessCount
+    });
+    if (shouldApplyHeadWound) {
+        await sheet._applyHeadshotSideEffect(notes);
+    }
+
+    const baseDmg = String(item.system.damage || item.system.dmg || '0');
+    const totalMod = mods.damage + mosDamageBonus;
+    const finalDmgFormula = buildWeaponDamageFormula(baseDmg, totalMod);
+    const showButton = isSuccess && finalDmgFormula && finalDmgFormula !== '0';
+
+    let adValue = Number(item.system.ad) || 0;
+    if (item.system.powersuitAttack) {
+        const adFromStrMinus = Number(item.system.adFromStrMinus) || 0;
+        if (adFromStrMinus > 0) {
+            adValue = Math.max(0, strValue - adFromStrMinus);
+        }
+    }
+
+    const notesText = notes.join(' ');
+    const templateData = buildWeaponRollTemplateData(sheet, {
+        item,
+        roll,
+        baseModifier,
+        notesText,
+        successDieModifier: mods.successDie,
+        resultColor,
+        sdTotal,
+        skillDiceData,
+        showDamageButton: showButton,
+        finalDamageFormula: finalDmgFormula,
+        adValue,
+        rofRerollSD,
+        isSuccess,
+        skillSuccessCount,
+        mosEffectText,
+        mosChoiceData
+    });
+
+    const chatContent = await foundry.applications.handlebars.renderTemplate(
+        'systems/sla-industries/templates/chat/chat-weapon-rolls.hbs',
+        templateData
+    );
+
+    roll.toMessage({
+        speaker: ChatMessage.getSpeaker({ actor: sheet.actor }),
+        content: chatContent,
+        flags: {
+            sla: sheet._buildSlaRollFlags({
+                baseModifier: baseModifier,
+                itemName: item.name.toUpperCase(),
+                notes: notesText,
+                tn: TN,
+                extra: {
+                    rofRerollSD: rofRerollSD,
+                    rofRerollSkills: rofRerollSkills,
+                    targets: Array.from(game.user.targets).map((t) => t.document.uuid),
+                    damageBase: baseDmg,
+                    damageMod: mods.damage,
+                    adValue: adValue,
+                    autoSkillSuccesses: mods.autoSkillSuccesses,
+                    successDieModifier: mods.successDie,
+                    isWeapon: true
+                }
+            })
+        }
+    });
+}

--- a/tests/unit/roll-math.test.mjs
+++ b/tests/unit/roll-math.test.mjs
@@ -4,11 +4,23 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+    applySuccessThroughExperience,
+    buildSkillDiceResults,
     buildSkillRollFormula,
+    computeMeleeStrDamageModifier,
     computeSkillRollModifier,
+    computeSuccessDieOutcome,
+    computeWeaponSkillDiceCount,
     buildWeaponDamageFormula,
+    resolveExplosiveBlastData,
     resolveWeaponMosOutcome
 } from '../../module/sheets/actor/roll-math.mjs';
+
+function mockWeaponRoll(successDieRaw, skillDieRaws = []) {
+    return {
+        terms: [{ results: [{ result: successDieRaw }] }, {}, { results: skillDieRaws.map((r) => ({ result: r })) }]
+    };
+}
 
 describe('buildSkillRollFormula', () => {
     test('rank 0 rolls one skill die', () => {
@@ -65,6 +77,59 @@ describe('buildWeaponDamageFormula', () => {
 
     test('returns modifier alone when base is zero', () => {
         assert.equal(buildWeaponDamageFormula('0', 2), '2');
+    });
+});
+
+describe('computeMeleeStrDamageModifier', () => {
+    test('scales STR bonus for melee damage', () => {
+        assert.equal(computeMeleeStrDamageModifier(5), 1);
+        assert.equal(computeMeleeStrDamageModifier(6), 2);
+        assert.equal(computeMeleeStrDamageModifier(7), 4);
+        assert.equal(computeMeleeStrDamageModifier(3), 0);
+    });
+});
+
+describe('computeSuccessDieOutcome', () => {
+    test('success when modified total meets TN', () => {
+        const r = computeSuccessDieOutcome({ sdRaw: 6, baseModifier: 4, successDieModifier: 0, targetNumber: 10 });
+        assert.equal(r.isBaseSuccess, true);
+        assert.equal(r.sdTotal, 10);
+    });
+});
+
+describe('applySuccessThroughExperience', () => {
+    test('converts failed SD with 4+ skill hits to success', () => {
+        const r = applySuccessThroughExperience({ isBaseSuccess: false, skillSuccessCount: 4 });
+        assert.equal(r.isSuccess, true);
+        assert.equal(r.successThroughExperience, true);
+        assert.ok(r.note);
+    });
+});
+
+describe('buildSkillDiceResults', () => {
+    test('counts skill dice at or above TN', () => {
+        const roll = mockWeaponRoll(3, [8, 4, 10]);
+        const { skillSuccessCount, skillDiceData } = buildSkillDiceResults({
+            roll,
+            baseModifier: 0,
+            targetNumber: 8
+        });
+        assert.equal(skillSuccessCount, 2);
+        assert.equal(skillDiceData.length, 3);
+    });
+});
+
+describe('computeWeaponSkillDiceCount', () => {
+    test('subtracts reserved and aim-auto dice from pool', () => {
+        assert.equal(computeWeaponSkillDiceCount(3, { reservedDice: 1, aimAuto: 1 }), 2);
+    });
+});
+
+describe('resolveExplosiveBlastData', () => {
+    test('defaults outer blast to 5 when unset', () => {
+        const d = resolveExplosiveBlastData({ blastRadiusInner: 2, blastRadiusOuter: 0 });
+        assert.equal(d.innerDist, 2);
+        assert.equal(d.outerDist, 5);
     });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues actor-sheet decomposition after roadmap PRs #286–#290:

- **`module/sheets/actor/weapon-rolls.mjs`** — attack dialog, `processWeaponRoll`, ROF rerolls, chat card assembly
- **`roll-math.mjs` extensions** — `computeSuccessDieOutcome`, `applySuccessThroughExperience`, `buildSkillDiceResults`, `computeMeleeStrDamageModifier`, `computeWeaponSkillDiceCount`, `readExplosiveRollForm`, `resolveExplosiveBlastData`
- **`SlaActorSheet`** delegates weapon rolls; explosive/Ebb still use thin wrappers to shared roll-math helpers
- **67 unit tests** (9 new roll-math tests)

`actor-sheet.mjs` is ~400 lines shorter. Explosive/Ebb orchestration is the next extraction target.

## Test plan

- [x] `npm run format:check`
- [x] `npm run test:unit` (67 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-166bebf7-53a8-4635-a81b-97baad83c205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-166bebf7-53a8-4635-a81b-97baad83c205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

