### PR TITLE
refactor: extract stat rolls and sheet UI actions (PR10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Explosive and Ebb roll extraction:** `module/sheets/actor/explosive-rolls.mjs` and `ebb-rolls.mjs` handle throw and Ebb formula orchestration; explosive/Ebb pure helpers in `roll-math.mjs` with unit tests.
 - **Chat module split:** `module/helpers/chat/` (`pure.mjs`, `dom.mjs`, `damage.mjs`, `handlers.mjs`) with unit tests for pure damage/wound helpers; native `document.body` click delegation replaces jQuery listeners.
 - **Actor sheet modules (PR9):** `reload.mjs`, `item-actions.mjs`, `weapon-gates.mjs`, `actor-drops.mjs`, and `sheet-helpers.mjs` with pure drop helpers in `actor-drops-pure.mjs` (unit tested).
+- **Actor sheet modules (PR10):** `stat-rolls.mjs`, `sheet-rolls.mjs`, `sheet-actions.mjs`, and `sheet-actions-pure.mjs` for stat checks and delegated sheet UI clicks/changes.
 
 ### Changed
 
@@ -28,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Actor sheet:** Explosive throw and Ebb formula roll paths delegate to `explosive-rolls.mjs` and `ebb-rolls.mjs` (~870 lines removed from `actor-sheet.mjs`).
 - **Chat:** `SLAChat` is a thin facade over split modules; chat card buttons use native DOM APIs instead of jQuery.
 - **Actor sheet:** Reload, item actions, drop handling, weapon gates, and shared roll helpers extracted from `actor-sheet.mjs` (~480 lines removed).
+- **Actor sheet:** Stat rolls and sheet click/change delegation moved to dedicated modules (`actor-sheet.mjs` now ~670 lines).
 
 ### Fixed
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -53,7 +53,11 @@ sla-industries/
 │       │   ├── weapon-gates.mjs # Equipped/target checks and combat loadout damage
 │       │   ├── actor-drops.mjs # Species/package/vehicle drop handling
 │       │   ├── actor-drops-pure.mjs # Pure drop validation helpers (unit tested)
-│       │   └── sheet-helpers.mjs # Shared tooltip, flags, and roll helpers
+│       │   ├── sheet-helpers.mjs # Shared tooltip, flags, and roll helpers
+│       │   ├── stat-rolls.mjs    # Stat check rolls from sheet
+│       │   ├── sheet-rolls.mjs   # Routes item/stat/skill/init roll clicks
+│       │   ├── sheet-actions.mjs # Sheet click/change UI delegation
+│       │   └── sheet-actions-pure.mjs # Pure species-removal helpers (unit tested)
 │       ├── actor-sheet.mjs     # SlaActorSheet (operative/character, ApplicationV2)
 │       ├── actor-npc-sheet.mjs # SlaNPCSheet (threat/NPC, ApplicationV2)
 │       ├── actor-vehicle-sheet.mjs  # SlaVehicleSheet (vehicle, ApplicationV2)

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,15 +1,13 @@
 /**
  * SLA actor sheet (Application V2).
  */
-import { XPDialog } from '../apps/xp-dialog.mjs';
-import { SlaSimpleContentDialog } from '../apps/sla-simple-dialog.mjs';
-import { createSLARoll } from '../helpers/dice.mjs';
 import { prepareItems } from '../helpers/items.mjs';
 import { applyMeleeModifiers, applyRangedModifiers } from '../helpers/modifiers.mjs';
 import { addActorItemToHotbar } from '../helpers/sla-hotbar.mjs';
 import { onDropItem, onDropVehicleWeapon, onItemCreate } from './actor/actor-drops.mjs';
-import { triggerItemRoll, useDrugItem } from './actor/item-actions.mjs';
-import { onReloadWeapon } from './actor/reload.mjs';
+import { triggerItemRoll } from './actor/item-actions.mjs';
+import { handleSheetChange, handleSheetClick } from './actor/sheet-actions.mjs';
+import { handleSheetRoll } from './actor/sheet-rolls.mjs';
 import {
     applyHeadshotSideEffect,
     applySuccessThroughExperienceForSheet,
@@ -20,11 +18,7 @@ import {
     resolveCombatSkillRank,
     resolveSheetDamageDisplay
 } from './actor/sheet-helpers.mjs';
-import {
-    canProceedWithWeaponAttack,
-    executeCombatLoadoutDamageRoll,
-    resolveRangedAttackContext
-} from './actor/weapon-gates.mjs';
+import { canProceedWithWeaponAttack, resolveRangedAttackContext } from './actor/weapon-gates.mjs';
 import { executeSkillRollFromItem } from './actor/skill-rolls.mjs';
 import { executeEbbRoll } from './actor/ebb-rolls.mjs';
 import { processExplosiveRoll, renderExplosiveDialog } from './actor/explosive-rolls.mjs';
@@ -437,43 +431,6 @@ export class SlaActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
         });
     }
 
-    /** App V2 does not attach FormApplication `[data-edit]` listeners; open image FilePicker for actor portrait. */
-    async #openActorImagePicker() {
-        const Picker = foundry.applications.apps?.FilePicker ?? globalThis.FilePicker;
-        if (!Picker) {
-            ui.notifications?.error?.('FilePicker is unavailable.');
-            return;
-        }
-        const fp = new Picker({
-            type: 'image',
-            current: this.actor.img,
-            callback: (path) => {
-                if (path) void this.actor.update({ img: path });
-            }
-        });
-        await fp.render(true);
-    }
-
-    /**
-     * App V2 replacement for Dialog.confirm.
-     * @param {string} title
-     * @param {string} contentHtml
-     * @param {() => Promise<void> | void} onConfirm
-     * @param {string} [actionLabel]
-     */
-    async #confirmAction(title, contentHtml, onConfirm, actionLabel = 'Confirm') {
-        await new SlaSimpleContentDialog({
-            title,
-            contentHtml,
-            width: 420,
-            classes: ['sla-dialog', 'sla-sheet'],
-            actionLabel,
-            onConfirm: async () => {
-                await onConfirm();
-            }
-        }).render(true);
-    }
-
     /**
      * ContextMenu.close() can animate via getBoundingClientRect on a target that is already detached
      * when the sheet closes. Skip animation and await so promise rejections are handled.
@@ -600,359 +557,15 @@ export class SlaActorSheet extends HandlebarsApplicationMixin(ActorSheetV2) {
     };
 
     #onSheetClick = async (event) => {
-        const t = event.target;
-        if (!(t instanceof Element)) return;
-
-        const cond = t.closest('.condition-toggle');
-        if (cond) {
-            event.preventDefault();
-            if (cond.classList.contains('condition-automatic')) return;
-            const conditionId = cond.dataset.condition;
-            if (conditionId) await this.actor.toggleStatusEffect(conditionId);
-            return;
-        }
-
-        const damageRoll = t.closest('.item-roll-damage');
-        if (damageRoll) {
-            event.preventDefault();
-            await executeCombatLoadoutDamageRoll(this, damageRoll);
-            return;
-        }
-
-        const rollable = t.closest('.item-rollable') || t.closest('.rollable');
-        if (rollable) {
-            event.preventDefault();
-            await this._onRoll(event, rollable);
-            return;
-        }
-
-        const comp = t.closest('.open-compendium');
-        if (comp) {
-            event.preventDefault();
-            const compendiumId = comp.dataset.compendium;
-            const pack = game.packs.get(compendiumId);
-            if (pack) pack.render(true);
-            else ui.notifications.warn(`Compendium '${compendiumId}' not found.`);
-            return;
-        }
-
-        const dataEdit = t.closest('[data-edit]');
-        if (dataEdit instanceof HTMLElement && this.isEditable && dataEdit.dataset.edit === 'img') {
-            event.preventDefault();
-            event.stopPropagation();
-            await this.#openActorImagePicker();
-            return;
-        }
-
-        if (!this.isEditable) return;
-
-        const drugBtn = t.closest('.item-use-drug');
-        if (drugBtn) {
-            event.preventDefault();
-            const li = drugBtn.closest('.item');
-            const itemId = li?.dataset.itemId;
-            const item = itemId ? this.actor.items.get(itemId) : null;
-            if (!item || item.type !== 'drug') return;
-            await useDrugItem(this, item);
-            return;
-        }
-
-        const toxicantBtn = t.closest('.item-use-toxicant');
-        if (toxicantBtn) {
-            event.preventDefault();
-            const li = toxicantBtn.closest('.item');
-            const itemId = li?.dataset.itemId;
-            const item = itemId ? this.actor.items.get(itemId) : null;
-            if (!item || item.type !== 'toxicant') return;
-            await item.rollInfectionTest();
-            return;
-        }
-
-        const effToggle = t.closest('.sla-effect-toggle');
-        if (effToggle && this.actor.isOwner) {
-            event.preventDefault();
-            const id = effToggle.dataset.effectId;
-            const effect = id ? this.actor.effects.get(id) : null;
-            if (effect) await effect.update({ disabled: !effect.disabled });
-            this.render(false);
-            return;
-        }
-        const effEdit = t.closest('.sla-effect-edit');
-        if (effEdit && this.actor.isOwner) {
-            event.preventDefault();
-            const id = effEdit.dataset.effectId;
-            const effect = id ? this.actor.effects.get(id) : null;
-            effect?.sheet?.render(true);
-            return;
-        }
-        const effDel = t.closest('.sla-effect-delete');
-        if (effDel && this.actor.isOwner) {
-            event.preventDefault();
-            const id = effDel.dataset.effectId;
-            const effect = id ? this.actor.effects.get(id) : null;
-            if (effect) await effect.delete();
-            this.render(false);
-            return;
-        }
-        const effAdd = t.closest('.sla-effect-create');
-        if (effAdd && this.actor.isOwner && this.isEditable) {
-            event.preventDefault();
-            await this.actor.createEmbeddedDocuments('ActiveEffect', [
-                {
-                    name: game.i18n.localize('DOCUMENT.ActiveEffect'),
-                    img: 'icons/svg/aura.svg',
-                    disabled: false
-                }
-            ]);
-            this.render(false);
-            return;
-        }
-
-        const chipSpecies = t.closest('.chip-delete[data-type="species"]');
-        if (chipSpecies) {
-            event.preventDefault();
-            event.stopPropagation();
-            const speciesItem = this.actor.items.find((i) => i.type === 'species');
-            if (!speciesItem) return;
-            await this.#confirmAction(
-                'Remove Species?',
-                `<p>Remove <strong>${speciesItem.name}</strong>?</p>`,
-                async () => {
-                    const skillsToDelete = this.actor.items
-                        .filter((i) => i.getFlag('sla-industries', 'fromSpecies'))
-                        .map((i) => i.id);
-                    await this.actor.deleteEmbeddedDocuments('Item', [speciesItem.id, ...skillsToDelete], {
-                        render: false
-                    });
-                    const resets = { 'system.bio.species': '' };
-                    ['str', 'dex', 'know', 'conc', 'cha', 'cool'].forEach(
-                        (k) => (resets[`system.stats.${k}.value`] = 1)
-                    );
-                    await this.actor.update(resets);
-                },
-                'Remove'
-            );
-            return;
-        }
-
-        const chipPackage = t.closest('.chip-delete[data-type="package"]');
-        if (chipPackage) {
-            event.preventDefault();
-            event.stopPropagation();
-            const packageItem = this.actor.items.find((i) => i.type === 'package');
-            if (!packageItem) return;
-            await this.#confirmAction(
-                'Remove Package?',
-                `<p>Remove <strong>${packageItem.name}</strong>?</p>`,
-                async () => {
-                    const skillsToDelete = this.actor.items
-                        .filter((i) => i.getFlag('sla-industries', 'fromPackage'))
-                        .map((i) => i.id);
-                    await this.actor.deleteEmbeddedDocuments('Item', [packageItem.id, ...skillsToDelete], {
-                        render: false
-                    });
-                    await this.actor.update({ 'system.bio.package': '' });
-                },
-                'Remove'
-            );
-            return;
-        }
-
-        const itemEdit = t.closest('.item-edit');
-        if (itemEdit) {
-            event.preventDefault();
-            const li = itemEdit.closest('.item');
-            const item = li?.dataset.itemId ? this.actor.items.get(li.dataset.itemId) : null;
-            if (item) item.sheet.render(true);
-            return;
-        }
-
-        const itemDelete = t.closest('.item-delete');
-        if (itemDelete) {
-            event.preventDefault();
-            const li = itemDelete.closest('.item');
-            const item = li?.dataset.itemId ? this.actor.items.get(li.dataset.itemId) : null;
-            if (item) {
-                await this.#confirmAction(
-                    'Delete Item?',
-                    '<p>Are you sure?</p>',
-                    async () => {
-                        await item.delete();
-                        this.render(false);
-                    },
-                    'Delete'
-                );
-            }
-            return;
-        }
-
-        const itemToggle = t.closest('.item-toggle');
-        if (itemToggle) {
-            event.preventDefault();
-            const li = itemToggle.closest('.item');
-            const item = li?.dataset.itemId ? this.actor.items.get(li.dataset.itemId) : null;
-            if (!item) return;
-            if (item.type === 'drug') await item.toggleActive();
-            else await item.update({ 'system.equipped': !item.system.equipped });
-            return;
-        }
-
-        const itemReload = t.closest('.item-reload');
-        if (itemReload) {
-            await onReloadWeapon(this, event, itemReload);
-            return;
-        }
-
-        const itemCreate = t.closest('.item-create');
-        if (itemCreate) {
-            await onItemCreate(this, event, itemCreate);
-            return;
-        }
-
-        const xpBtn = t.closest('.xp-button');
-        if (xpBtn) {
-            event.preventDefault();
-            await XPDialog.create(this.actor);
-        }
+        await handleSheetClick(this, event);
     };
 
     #onSheetChange = async (event) => {
-        const root = event.currentTarget;
-        if (!(root instanceof HTMLElement)) return;
-
-        const el = event.target instanceof Element ? event.target : null;
-        if (!el) return;
-
-        const inlineInput = el.closest('.inline-edit');
-        if (inlineInput) {
-            if (!this.isEditable) return;
-            event.preventDefault();
-            const input = inlineInput;
-            const row = input.closest('.item');
-            const itemId = input.dataset.itemId || row?.dataset.itemId;
-            if (!itemId) return;
-            const item = this.actor.items.get(itemId);
-            const field = input.dataset.field;
-            if (item && field) await item.update({ [field]: Number(input.value) });
-            return;
-        }
-
-        const woundCb = el.closest('.wound-checkbox');
-        if (woundCb) {
-            const field = woundCb.name;
-            const isChecked = woundCb.checked;
-            if (this.actor.type === 'npc') {
-                const systemPath = field.replace('system.', '');
-                const currentValue = foundry.utils.getProperty(this.actor.system, systemPath);
-                if (currentValue === isChecked) return;
-            }
-            const updateData = { [field]: isChecked };
-            try {
-                await this.actor.update(updateData);
-            } catch (error) {
-                console.error('SLA Industries | Error updating actor:', error);
-                woundCb.checked = !isChecked;
-            }
-        }
+        await handleSheetChange(this, event);
     };
 
-    /* -------------------------------------------- */
-    /* ROLL HANDLERS                               */
-    /* -------------------------------------------- */
-
-    /**
-     * Handle clickable rolls.
-     * @param {PointerEvent} event   The originating click event (must be a real event; do not spread into a plain object)
-     * @param {HTMLElement} [rollTarget]  The `.rollable` / `.item-rollable` element (required for delegated clicks where `event.currentTarget` is the sheet root)
-     * @private
-     */
     async _onRoll(event, rollTarget) {
-        event.preventDefault();
-        const element = rollTarget ?? event.currentTarget;
-        const dataset = element.dataset;
-
-        // Handle Item Rolls (triggered by your crosshairs icon)
-        if (dataset.rollType === 'item') {
-            const itemId = element.closest('.item')?.dataset.itemId;
-            const item = itemId ? this.actor.items.get(itemId) : null;
-            if (item) await this.triggerItemRoll(item);
-        }
-
-        let globalMod = 0;
-        if (this.actor.system.conditions?.prone) globalMod -= 1;
-        if (this.actor.system.conditions?.stunned) globalMod -= 1;
-
-        // STAT ROLL
-        if (dataset.rollType === 'stat') {
-            const statKey = dataset.key.toLowerCase();
-            const statLabel = statKey.toUpperCase();
-            const statValue = this.actor.system.stats[statKey]?.total ?? this.actor.system.stats[statKey]?.value ?? 0;
-            const penalty = this.actor.system.wounds.penalty || 0;
-            const finalMod =
-                statValue -
-                (game.settings.get('sla-industries', 'enableAutomaticWoundPenalties') ? penalty : 0) +
-                globalMod;
-
-            let roll = createSLARoll('1d10');
-            // ---------------------------------------------
-            await roll.evaluate();
-
-            let rawDie = roll.terms[0].results[0].result;
-            let finalTotal = rawDie + finalMod;
-            const resultColor = finalTotal > 10 ? '#39ff14' : '#f55';
-
-            const tooltipHtml = this._generateTooltip(roll, finalMod, 0, 0);
-
-            const isSuccess = finalTotal > 10;
-
-            const templateData = {
-                borderColor: resultColor,
-                headerColor: resultColor,
-                resultColor: resultColor,
-                actorUuid: this.actor.uuid,
-                itemName: `${statLabel} CHECK`,
-                successTotal: finalTotal,
-                tooltip: tooltipHtml,
-                skillDice: [],
-                notes: '',
-                showDamageButton: false,
-                // Luck Data
-                canUseLuck: this.actor.system.stats.luck.value > 0,
-                luckValue: this.actor.system.stats.luck.value,
-                luckSpent: false,
-                mos: {
-                    isSuccess: isSuccess,
-                    hits: 0,
-                    effect: isSuccess ? 'Success' : 'Failure'
-                }
-            };
-
-            const chatContent = await foundry.applications.handlebars.renderTemplate(
-                'systems/sla-industries/templates/chat/chat-weapon-rolls.hbs',
-                templateData
-            );
-
-            roll.toMessage({
-                speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-                content: chatContent,
-                flags: {
-                    sla: this._buildSlaRollFlags({
-                        baseModifier: finalMod,
-                        itemName: `${statLabel} CHECK`,
-                        notes: '',
-                        tn: 10
-                    })
-                }
-            });
-        }
-
-        if (dataset.rollType === 'skill') {
-            this._executeSkillRoll(element);
-        }
-
-        if (dataset.rollType === 'init') {
-            await this.actor.rollInitiative({ createCombatants: true });
-        }
+        return handleSheetRoll(this, event, rollTarget);
     }
 
     _canProceedWithWeaponAttack(item, options) {

--- a/module/sheets/actor/roll-math.mjs
+++ b/module/sheets/actor/roll-math.mjs
@@ -27,6 +27,15 @@ export function computeSkillRollModifier({ statValue, rank, prone, stunned, woun
 }
 
 /**
+ * Stat checks succeed when the modified total exceeds the target (legacy SLA: > 10).
+ * @param {number} finalTotal
+ * @param {number} [targetNumber=10]
+ */
+export function isStatCheckSuccess(finalTotal, targetNumber = 10) {
+    return finalTotal > targetNumber;
+}
+
+/**
  * @param {string} baseDamage
  * @param {number} totalModifier
  * @returns {string}

--- a/module/sheets/actor/sheet-actions-pure.mjs
+++ b/module/sheets/actor/sheet-actions-pure.mjs
@@ -1,0 +1,16 @@
+/**
+ * Pure helpers for actor sheet UI actions (unit tested).
+ */
+
+export const SPECIES_REMOVAL_STAT_KEYS = ['str', 'dex', 'know', 'conc', 'cha', 'cool'];
+
+/**
+ * Actor updates applied when removing a species chip from the sheet.
+ */
+export function buildSpeciesRemovalUpdates() {
+    const updates = { 'system.bio.species': '' };
+    for (const key of SPECIES_REMOVAL_STAT_KEYS) {
+        updates[`system.stats.${key}.value`] = 1;
+    }
+    return updates;
+}

--- a/module/sheets/actor/sheet-actions.mjs
+++ b/module/sheets/actor/sheet-actions.mjs
@@ -1,0 +1,297 @@
+import { XPDialog } from '../../apps/xp-dialog.mjs';
+import { SlaSimpleContentDialog } from '../../apps/sla-simple-dialog.mjs';
+import { onItemCreate } from './actor-drops.mjs';
+import { onReloadWeapon } from './reload.mjs';
+import { useDrugItem } from './item-actions.mjs';
+import { executeCombatLoadoutDamageRoll } from './weapon-gates.mjs';
+import { buildSpeciesRemovalUpdates } from './sheet-actions-pure.mjs';
+import { handleSheetRoll } from './sheet-rolls.mjs';
+
+/** @param {import('../actor-sheet.mjs').SlaActorSheet} sheet */
+export async function openActorImagePicker(sheet) {
+    const Picker = foundry.applications.apps?.FilePicker ?? globalThis.FilePicker;
+    if (!Picker) {
+        ui.notifications?.error?.('FilePicker is unavailable.');
+        return;
+    }
+    const fp = new Picker({
+        type: 'image',
+        current: sheet.actor.img,
+        callback: (path) => {
+            if (path) void sheet.actor.update({ img: path });
+        }
+    });
+    await fp.render(true);
+}
+
+/** @param {import('../actor-sheet.mjs').SlaActorSheet} sheet */
+export async function confirmSheetAction(sheet, title, contentHtml, onConfirm, actionLabel = 'Confirm') {
+    await new SlaSimpleContentDialog({
+        title,
+        contentHtml,
+        width: 420,
+        classes: ['sla-dialog', 'sla-sheet'],
+        actionLabel,
+        onConfirm: async () => {
+            await onConfirm();
+        }
+    }).render(true);
+}
+
+/** @param {import('../actor-sheet.mjs').SlaActorSheet} sheet */
+export async function handleSheetClick(sheet, event) {
+    const t = event.target;
+    if (!(t instanceof Element)) return;
+
+    const cond = t.closest('.condition-toggle');
+    if (cond) {
+        event.preventDefault();
+        if (cond.classList.contains('condition-automatic')) return;
+        const conditionId = cond.dataset.condition;
+        if (conditionId) await sheet.actor.toggleStatusEffect(conditionId);
+        return;
+    }
+
+    const damageRoll = t.closest('.item-roll-damage');
+    if (damageRoll) {
+        event.preventDefault();
+        await executeCombatLoadoutDamageRoll(sheet, damageRoll);
+        return;
+    }
+
+    const rollable = t.closest('.item-rollable') || t.closest('.rollable');
+    if (rollable) {
+        event.preventDefault();
+        await handleSheetRoll(sheet, event, rollable);
+        return;
+    }
+
+    const comp = t.closest('.open-compendium');
+    if (comp) {
+        event.preventDefault();
+        const compendiumId = comp.dataset.compendium;
+        const pack = game.packs.get(compendiumId);
+        if (pack) pack.render(true);
+        else ui.notifications.warn(`Compendium '${compendiumId}' not found.`);
+        return;
+    }
+
+    const dataEdit = t.closest('[data-edit]');
+    if (dataEdit instanceof HTMLElement && sheet.isEditable && dataEdit.dataset.edit === 'img') {
+        event.preventDefault();
+        event.stopPropagation();
+        await openActorImagePicker(sheet);
+        return;
+    }
+
+    if (!sheet.isEditable) return;
+
+    const drugBtn = t.closest('.item-use-drug');
+    if (drugBtn) {
+        event.preventDefault();
+        const li = drugBtn.closest('.item');
+        const itemId = li?.dataset.itemId;
+        const item = itemId ? sheet.actor.items.get(itemId) : null;
+        if (!item || item.type !== 'drug') return;
+        await useDrugItem(sheet, item);
+        return;
+    }
+
+    const toxicantBtn = t.closest('.item-use-toxicant');
+    if (toxicantBtn) {
+        event.preventDefault();
+        const li = toxicantBtn.closest('.item');
+        const itemId = li?.dataset.itemId;
+        const item = itemId ? sheet.actor.items.get(itemId) : null;
+        if (!item || item.type !== 'toxicant') return;
+        await item.rollInfectionTest();
+        return;
+    }
+
+    const effToggle = t.closest('.sla-effect-toggle');
+    if (effToggle && sheet.actor.isOwner) {
+        event.preventDefault();
+        const id = effToggle.dataset.effectId;
+        const effect = id ? sheet.actor.effects.get(id) : null;
+        if (effect) await effect.update({ disabled: !effect.disabled });
+        sheet.render(false);
+        return;
+    }
+    const effEdit = t.closest('.sla-effect-edit');
+    if (effEdit && sheet.actor.isOwner) {
+        event.preventDefault();
+        const id = effEdit.dataset.effectId;
+        const effect = id ? sheet.actor.effects.get(id) : null;
+        effect?.sheet?.render(true);
+        return;
+    }
+    const effDel = t.closest('.sla-effect-delete');
+    if (effDel && sheet.actor.isOwner) {
+        event.preventDefault();
+        const id = effDel.dataset.effectId;
+        const effect = id ? sheet.actor.effects.get(id) : null;
+        if (effect) await effect.delete();
+        sheet.render(false);
+        return;
+    }
+    const effAdd = t.closest('.sla-effect-create');
+    if (effAdd && sheet.actor.isOwner && sheet.isEditable) {
+        event.preventDefault();
+        await sheet.actor.createEmbeddedDocuments('ActiveEffect', [
+            {
+                name: game.i18n.localize('DOCUMENT.ActiveEffect'),
+                img: 'icons/svg/aura.svg',
+                disabled: false
+            }
+        ]);
+        sheet.render(false);
+        return;
+    }
+
+    const chipSpecies = t.closest('.chip-delete[data-type="species"]');
+    if (chipSpecies) {
+        event.preventDefault();
+        event.stopPropagation();
+        const speciesItem = sheet.actor.items.find((i) => i.type === 'species');
+        if (!speciesItem) return;
+        await confirmSheetAction(
+            sheet,
+            'Remove Species?',
+            `<p>Remove <strong>${speciesItem.name}</strong>?</p>`,
+            async () => {
+                const skillsToDelete = sheet.actor.items
+                    .filter((i) => i.getFlag('sla-industries', 'fromSpecies'))
+                    .map((i) => i.id);
+                await sheet.actor.deleteEmbeddedDocuments('Item', [speciesItem.id, ...skillsToDelete], {
+                    render: false
+                });
+                await sheet.actor.update(buildSpeciesRemovalUpdates());
+            },
+            'Remove'
+        );
+        return;
+    }
+
+    const chipPackage = t.closest('.chip-delete[data-type="package"]');
+    if (chipPackage) {
+        event.preventDefault();
+        event.stopPropagation();
+        const packageItem = sheet.actor.items.find((i) => i.type === 'package');
+        if (!packageItem) return;
+        await confirmSheetAction(
+            sheet,
+            'Remove Package?',
+            `<p>Remove <strong>${packageItem.name}</strong>?</p>`,
+            async () => {
+                const skillsToDelete = sheet.actor.items
+                    .filter((i) => i.getFlag('sla-industries', 'fromPackage'))
+                    .map((i) => i.id);
+                await sheet.actor.deleteEmbeddedDocuments('Item', [packageItem.id, ...skillsToDelete], {
+                    render: false
+                });
+                await sheet.actor.update({ 'system.bio.package': '' });
+            },
+            'Remove'
+        );
+        return;
+    }
+
+    const itemEdit = t.closest('.item-edit');
+    if (itemEdit) {
+        event.preventDefault();
+        const li = itemEdit.closest('.item');
+        const item = li?.dataset.itemId ? sheet.actor.items.get(li.dataset.itemId) : null;
+        if (item) item.sheet.render(true);
+        return;
+    }
+
+    const itemDelete = t.closest('.item-delete');
+    if (itemDelete) {
+        event.preventDefault();
+        const li = itemDelete.closest('.item');
+        const item = li?.dataset.itemId ? sheet.actor.items.get(li.dataset.itemId) : null;
+        if (item) {
+            await confirmSheetAction(
+                sheet,
+                'Delete Item?',
+                '<p>Are you sure?</p>',
+                async () => {
+                    await item.delete();
+                    sheet.render(false);
+                },
+                'Delete'
+            );
+        }
+        return;
+    }
+
+    const itemToggle = t.closest('.item-toggle');
+    if (itemToggle) {
+        event.preventDefault();
+        const li = itemToggle.closest('.item');
+        const item = li?.dataset.itemId ? sheet.actor.items.get(li.dataset.itemId) : null;
+        if (!item) return;
+        if (item.type === 'drug') await item.toggleActive();
+        else await item.update({ 'system.equipped': !item.system.equipped });
+        return;
+    }
+
+    const itemReload = t.closest('.item-reload');
+    if (itemReload) {
+        await onReloadWeapon(sheet, event, itemReload);
+        return;
+    }
+
+    const itemCreate = t.closest('.item-create');
+    if (itemCreate) {
+        await onItemCreate(sheet, event, itemCreate);
+        return;
+    }
+
+    const xpBtn = t.closest('.xp-button');
+    if (xpBtn) {
+        event.preventDefault();
+        await XPDialog.create(sheet.actor);
+    }
+}
+
+/** @param {import('../actor-sheet.mjs').SlaActorSheet} sheet */
+export async function handleSheetChange(sheet, event) {
+    const root = event.currentTarget;
+    if (!(root instanceof HTMLElement)) return;
+
+    const el = event.target instanceof Element ? event.target : null;
+    if (!el) return;
+
+    const inlineInput = el.closest('.inline-edit');
+    if (inlineInput) {
+        if (!sheet.isEditable) return;
+        event.preventDefault();
+        const input = inlineInput;
+        const row = input.closest('.item');
+        const itemId = input.dataset.itemId || row?.dataset.itemId;
+        if (!itemId) return;
+        const item = sheet.actor.items.get(itemId);
+        const field = input.dataset.field;
+        if (item && field) await item.update({ [field]: Number(input.value) });
+        return;
+    }
+
+    const woundCb = el.closest('.wound-checkbox');
+    if (woundCb) {
+        const field = woundCb.name;
+        const isChecked = woundCb.checked;
+        if (sheet.actor.type === 'npc') {
+            const systemPath = field.replace('system.', '');
+            const currentValue = foundry.utils.getProperty(sheet.actor.system, systemPath);
+            if (currentValue === isChecked) return;
+        }
+        const updateData = { [field]: isChecked };
+        try {
+            await sheet.actor.update(updateData);
+        } catch (error) {
+            console.error('SLA Industries | Error updating actor:', error);
+            woundCb.checked = !isChecked;
+        }
+    }
+}

--- a/module/sheets/actor/sheet-rolls.mjs
+++ b/module/sheets/actor/sheet-rolls.mjs
@@ -1,0 +1,37 @@
+import { executeSkillRollFromItem } from './skill-rolls.mjs';
+import { executeStatRoll } from './stat-rolls.mjs';
+import { triggerItemRoll } from './item-actions.mjs';
+
+/**
+ * @param {import('../actor-sheet.mjs').SlaActorSheet} sheet
+ * @param {PointerEvent} event
+ * @param {HTMLElement} [rollTarget]
+ */
+export async function handleSheetRoll(sheet, event, rollTarget) {
+    event.preventDefault();
+    const element = rollTarget ?? event.currentTarget;
+    const dataset = element.dataset;
+
+    if (dataset.rollType === 'item') {
+        const itemId = element.closest('.item')?.dataset.itemId;
+        const item = itemId ? sheet.actor.items.get(itemId) : null;
+        if (item) await triggerItemRoll(sheet, item);
+        return;
+    }
+
+    if (dataset.rollType === 'stat') {
+        await executeStatRoll(sheet, dataset.key);
+        return;
+    }
+
+    if (dataset.rollType === 'skill') {
+        const itemId = element.closest('.item')?.dataset.itemId;
+        const item = itemId ? sheet.actor.items.get(itemId) : null;
+        if (item) await executeSkillRollFromItem(sheet, item);
+        return;
+    }
+
+    if (dataset.rollType === 'init') {
+        await sheet.actor.rollInitiative({ createCombatants: true });
+    }
+}

--- a/module/sheets/actor/stat-rolls.mjs
+++ b/module/sheets/actor/stat-rolls.mjs
@@ -1,0 +1,69 @@
+import { createSLARoll } from '../../helpers/dice.mjs';
+import { computeSkillRollModifier, isStatCheckSuccess } from './roll-math.mjs';
+import { buildSlaRollFlags, generateSheetTooltip } from './sheet-helpers.mjs';
+
+/**
+ * @param {import('../actor-sheet.mjs').SlaActorSheet} sheet
+ * @param {string} statKey
+ */
+export async function executeStatRoll(sheet, statKey) {
+    const actor = sheet.actor;
+    const normalizedKey = statKey.toLowerCase();
+    const statLabel = normalizedKey.toUpperCase();
+    const statValue = actor.system.stats[normalizedKey]?.total ?? actor.system.stats[normalizedKey]?.value ?? 0;
+
+    const finalMod = computeSkillRollModifier({
+        statValue,
+        rank: 0,
+        prone: Boolean(actor.system.conditions?.prone),
+        stunned: Boolean(actor.system.conditions?.stunned),
+        woundPenalty: actor.system.wounds.penalty || 0,
+        applyWoundPenalties: game.settings.get('sla-industries', 'enableAutomaticWoundPenalties')
+    });
+
+    const roll = createSLARoll('1d10');
+    await roll.evaluate();
+
+    const finalTotal = roll.terms[0].results[0].result + finalMod;
+    const isSuccess = isStatCheckSuccess(finalTotal);
+    const resultColor = isSuccess ? '#39ff14' : '#f55';
+
+    const templateData = {
+        borderColor: resultColor,
+        headerColor: resultColor,
+        resultColor: resultColor,
+        actorUuid: actor.uuid,
+        itemName: `${statLabel} CHECK`,
+        successTotal: finalTotal,
+        tooltip: generateSheetTooltip(roll, finalMod, 0),
+        skillDice: [],
+        notes: '',
+        showDamageButton: false,
+        canUseLuck: actor.system.stats.luck.value > 0,
+        luckValue: actor.system.stats.luck.value,
+        luckSpent: false,
+        mos: {
+            isSuccess: isSuccess,
+            hits: 0,
+            effect: isSuccess ? 'Success' : 'Failure'
+        }
+    };
+
+    const chatContent = await foundry.applications.handlebars.renderTemplate(
+        'systems/sla-industries/templates/chat/chat-weapon-rolls.hbs',
+        templateData
+    );
+
+    roll.toMessage({
+        speaker: ChatMessage.getSpeaker({ actor }),
+        content: chatContent,
+        flags: {
+            sla: buildSlaRollFlags({
+                baseModifier: finalMod,
+                itemName: `${statLabel} CHECK`,
+                notes: '',
+                tn: 10
+            })
+        }
+    });
+}

--- a/tests/unit/roll-math.test.mjs
+++ b/tests/unit/roll-math.test.mjs
@@ -15,6 +15,7 @@ import {
     computeMeleeStrDamageModifier,
     computeSkillRollModifier,
     computeSuccessDieOutcome,
+    isStatCheckSuccess,
     computeWeaponSkillDiceCount,
     buildWeaponDamageFormula,
     resolveEbbDisciplineName,
@@ -36,6 +37,13 @@ describe('buildSkillRollFormula', () => {
 
     test('rank 2 rolls three skill dice', () => {
         assert.equal(buildSkillRollFormula(2), '1d10 + 3d10');
+    });
+});
+
+describe('isStatCheckSuccess', () => {
+    test('requires total above TN for stat checks', () => {
+        assert.equal(isStatCheckSuccess(10), false);
+        assert.equal(isStatCheckSuccess(11), true);
     });
 });
 

--- a/tests/unit/sheet-actions-pure.test.mjs
+++ b/tests/unit/sheet-actions-pure.test.mjs
@@ -1,0 +1,12 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSpeciesRemovalUpdates } from '../../module/sheets/actor/sheet-actions-pure.mjs';
+
+describe('buildSpeciesRemovalUpdates', () => {
+    test('clears species bio and resets core stats to 1', () => {
+        const updates = buildSpeciesRemovalUpdates();
+        assert.equal(updates['system.bio.species'], '');
+        assert.equal(updates['system.stats.str.value'], 1);
+        assert.equal(updates['system.stats.cool.value'], 1);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Roadmap PR10: final major slice of `actor-sheet.mjs` decomposition — stat checks and all delegated sheet UI click/change handling.

## Changes

- **`stat-rolls.mjs`** — stat check rolls (1d10 + modifiers, chat card)
- **`sheet-rolls.mjs`** — routes item / stat / skill / initiative roll clicks
- **`sheet-actions.mjs`** — conditions, effects, items, species/package chips, XP, image picker, confirm dialogs
- **`sheet-actions-pure.mjs`** — species removal stat resets (unit tested)
- **`roll-math.mjs`** — `isStatCheckSuccess()` helper
- **`actor-sheet.mjs`** — **1057 → 670 lines**

## Test plan

- [x] `npm run format:check`
- [x] `npm run test:unit` (94 tests, +2 new)
- [x] `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-166bebf7-53a8-4635-a81b-97baad83c205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-166bebf7-53a8-4635-a81b-97baad83c205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

