### PR TITLE
refactor: rename BoilerplateActor/Item to SlaActor/SlaItem (PR11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Natural weapons migration tests:** `classifyLegacyNaturalWeapon()` unit tests in `tests/unit/natural-weapons-migration.test.mjs`.
 - **Item sheet UI E2E regression:** Playwright spec `tests/e2e/regression-item-sheets.spec.js` covers discipline, ebb formula, weapon, magazine, skill, and generic item sheets (tabs, spectral stamps, shared drop hints, drag-over feedback, effects tab CRUD). Included in `npm run test:e2e:regression`.
 - **Data model registry:** `module/data/registry.mjs` and `module/data/model-type-keys.mjs` centralize `CONFIG.*.dataModels` registration; unit test asserts parity with `system.json` `documentTypes`.
-- **Derived data helpers:** Pure encumbrance, wound, and penalty calculators in `module/documents/derived/` with unit tests; `BoilerplateActor` delegates to these modules.
+- **Derived data helpers:** Pure encumbrance, wound, and penalty calculators in `module/documents/derived/` with unit tests; `SlaActor` delegates to these modules.
 - **Actor roll modules:** `module/sheets/actor/roll-math.mjs` (pure weapon/skill roll math) and `skill-rolls.mjs` (skill roll execution); unit tests for roll math.
 - **Weapon roll extraction:** `module/sheets/actor/weapon-rolls.mjs` handles attack dialog and weapon roll orchestration; additional pure helpers in `roll-math.mjs`.
 - **Explosive and Ebb roll extraction:** `module/sheets/actor/explosive-rolls.mjs` and `ebb-rolls.mjs` handle throw and Ebb formula orchestration; explosive/Ebb pure helpers in `roll-math.mjs` with unit tests.
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Document classes:** `BoilerplateActor` → `SlaActor` and `BoilerplateItem` → `SlaItem`. `BoilerplateActor` / `BoilerplateItem` remain as deprecated aliases on `game.boilerplate` and module exports for macro compatibility. `game.sla` now also exposes `SlaActor` and `SlaItem`.
 - **Natural weapons migration:** Moved from `scripts/migrate_stat_damage.js` to `module/migration/natural-weapons.mjs` so dev and `dist/` share the same import path; removed `dist/scripts/` copy step.
 - **Foundry cloud bootstrap:** `foundry-bootstrap.mjs` confirms world data migration and pre-migration backup dialogs so E2E can launch `sla-test-world` after system version bumps.
 - **Compiled CSS:** `css/sla-industries.css` is no longer committed; run `npm run build:css` or `npm run build` before local Foundry dev (CI and `cloud-foundry.sh` already build CSS).

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -24,8 +24,8 @@ sla-industries/
 │   │   └── natural-weapons.mjs # Punch/Kick baseline definitions
 │   ├── documents/
 │   │   ├── derived/            # Pure derived-data calculators (encumbrance, wounds, penalties)
-│   │   ├── actor.mjs           # BoilerplateActor — derived data, active effects, HP sync
-│   │   └── item.mjs            # BoilerplateItem
+│   │   ├── actor.mjs           # SlaActor — derived data, active effects, HP sync
+│   │   └── item.mjs            # SlaItem
 │   ├── helpers/
 │   │   ├── chat.mjs            # SLAChat facade — chat card rendering and button handlers
 │   │   └── chat/               # Chat split: pure.mjs, dom.mjs, damage.mjs, handlers.mjs
@@ -120,7 +120,7 @@ Core stats (`str`, `dex`, `know`, `conc`, `cha`, `cool`) each have a `value` (sh
 
 ---
 
-## Derived Data (`BoilerplateActor.prepareDerivedData`)
+## Derived Data (`SlaActor.prepareDerivedData`)
 
 `module/documents/actor.mjs` handles all derived calculations, including:
 
@@ -200,6 +200,10 @@ Creates or reuses a script macro for the given embedded item and assigns it to t
 ### `game.sla.canTokenMoveThisTurn(tokenLike)`
 
 Returns `true` if the token is allowed to move this turn (respects the **Enable Combat Movement Lock** setting and per-turn movement state).
+
+### `game.sla.SlaActor` / `game.sla.SlaItem`
+
+The registered Actor and Item document classes (`CONFIG.Actor.documentClass` / `CONFIG.Item.documentClass`). Legacy names `BoilerplateActor` and `BoilerplateItem` remain on `game.boilerplate` and as module export aliases.
 
 Source: `module/helpers/sla-hotbar.mjs`, `module/sla-industries.mjs`
 
@@ -372,7 +376,7 @@ Chat state is persisted on `ChatMessage.flags.sla`:
 
 ### Wound cascade
 
-`BoilerplateActor._handleWoundEffects()` runs on every wound field change:
+`SlaActor._handleWoundEffects()` runs on every wound field change:
 
 - **Head wound** → applies `stunned` status effect.
 - **Both leg wounds** → applies `immobile` status effect.

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -12,7 +12,7 @@ import { countWounds, deriveLogicConditions } from './derived/wounds.mjs';
  * Extend the basic Actor document.
  * @extends {Actor}
  */
-export class BoilerplateActor extends Actor {
+export class SlaActor extends Actor {
     /**
      * Active effect change rows (Foundry 14 may store under effect.system.changes).
      * @param {ActiveEffect} effect
@@ -38,7 +38,7 @@ export class BoilerplateActor extends Actor {
         let sum = 0;
         for (const effect of this.effects ?? []) {
             if (effect.disabled) continue;
-            for (const ch of BoilerplateActor._effectChangeRows(effect)) {
+            for (const ch of SlaActor._effectChangeRows(effect)) {
                 if (ch.mode !== addMode) continue;
                 if (ch.key === kb || ch.key === kv) sum += Number(ch.value) || 0;
             }
@@ -947,3 +947,6 @@ export class BoilerplateActor extends Actor {
         }
     }
 }
+
+/** @deprecated Use {@link SlaActor} — legacy boilerplate name kept for macro compatibility. */
+export const BoilerplateActor = SlaActor;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -10,7 +10,7 @@ import {
  * Extend the basic Item with some very simple modifications.
  * @extends {Item}
  */
-export class BoilerplateItem extends Item {
+export class SlaItem extends Item {
     prepareDerivedData() {
         super.prepareDerivedData();
     }
@@ -262,6 +262,9 @@ export class BoilerplateItem extends Item {
         }
     }
 }
+
+/** @deprecated Use {@link SlaItem} — legacy boilerplate name kept for macro compatibility. */
+export const BoilerplateItem = SlaItem;
 
 /**
  * @param {number} sdRaw

--- a/module/sla-industries.mjs
+++ b/module/sla-industries.mjs
@@ -1,6 +1,6 @@
 // Import document classes.
-import { BoilerplateActor } from './documents/actor.mjs';
-import { BoilerplateItem } from './documents/item.mjs';
+import { BoilerplateActor, SlaActor } from './documents/actor.mjs';
+import { BoilerplateItem, SlaItem } from './documents/item.mjs';
 import { LuckDialog } from './apps/luck-dialog.mjs';
 
 import { ACTOR_DATA_MODELS, ITEM_DATA_MODELS } from './data/registry.mjs';
@@ -126,9 +126,16 @@ Hooks.once('init', async function () {
 
     CONFIG.SLA = SLA;
 
-    game.boilerplate = { SlaActorSheet, SlaItemSheet, BoilerplateActor, BoilerplateItem };
-    CONFIG.Actor.documentClass = BoilerplateActor;
-    CONFIG.Item.documentClass = BoilerplateItem;
+    game.boilerplate = {
+        SlaActorSheet,
+        SlaItemSheet,
+        SlaActor,
+        SlaItem,
+        BoilerplateActor,
+        BoilerplateItem
+    };
+    CONFIG.Actor.documentClass = SlaActor;
+    CONFIG.Item.documentClass = SlaItem;
 
     // REGISTER DATA MODELS
     CONFIG.Actor.dataModels = ACTOR_DATA_MODELS;
@@ -281,7 +288,9 @@ Hooks.once('init', async function () {
     game.sla = foundry.utils.mergeObject(game.sla ?? {}, {
         rollOwnedItem,
         addActorItemToHotbar,
-        canTokenMoveThisTurn
+        canTokenMoveThisTurn,
+        SlaActor,
+        SlaItem
     });
 
     return preloadHandlebarsTemplates();

--- a/tests/unit/document-classes.test.mjs
+++ b/tests/unit/document-classes.test.mjs
@@ -1,0 +1,36 @@
+/**
+ * Document class rename contracts (static source checks; no Foundry runtime).
+ */
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '../..');
+
+describe('SlaActor document class', () => {
+    test('exports SlaActor with BoilerplateActor alias in actor.mjs', () => {
+        const src = readFileSync(join(root, 'module/documents/actor.mjs'), 'utf8');
+        assert.match(src, /export class SlaActor extends Actor/);
+        assert.match(src, /export const BoilerplateActor = SlaActor/);
+    });
+});
+
+describe('SlaItem document class', () => {
+    test('exports SlaItem with BoilerplateItem alias in item.mjs', () => {
+        const src = readFileSync(join(root, 'module/documents/item.mjs'), 'utf8');
+        assert.match(src, /export class SlaItem extends Item/);
+        assert.match(src, /export const BoilerplateItem = SlaItem/);
+    });
+});
+
+describe('sla-industries init registration', () => {
+    test('registers SlaActor/SlaItem on CONFIG and game APIs', () => {
+        const src = readFileSync(join(root, 'module/sla-industries.mjs'), 'utf8');
+        assert.match(src, /CONFIG\.Actor\.documentClass = SlaActor/);
+        assert.match(src, /CONFIG\.Item\.documentClass = SlaItem/);
+        assert.match(src, /SlaActor,\s*\n\s*SlaItem/);
+        assert.match(src, /BoilerplateActor,\s*\n\s*BoilerplateItem/);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Roadmap PR11: align document class names with the SLA branding used elsewhere (`SlaActorSheet`, `SlaItemSheet`, `SlaActorData`, etc.) while preserving backward compatibility for existing macros.

## Changes

- **`BoilerplateActor` → `SlaActor`** (`module/documents/actor.mjs`)
- **`BoilerplateItem` → `SlaItem`** (`module/documents/item.mjs`)
- **`CONFIG.Actor.documentClass` / `CONFIG.Item.documentClass`** now use `SlaActor` / `SlaItem`
- **`game.boilerplate`** exposes both canonical and legacy names
- **`game.sla`** adds `SlaActor` and `SlaItem` for macro authors
- Static source contract tests in `tests/unit/document-classes.test.mjs`

## Backward compatibility

`BoilerplateActor` and `BoilerplateItem` remain as:
- Module export aliases (`export const BoilerplateActor = SlaActor`)
- Keys on `game.boilerplate`

No breaking change for macros referencing `game.boilerplate.BoilerplateActor`.

## Test plan

- [x] `npm run format:check`
- [x] `npm run test:unit` (97 tests)
- [x] `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-166bebf7-53a8-4635-a81b-97baad83c205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-166bebf7-53a8-4635-a81b-97baad83c205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

