### PR TITLE
fix: v14 active effect compat + actor sheet E2E coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Chat module split:** `module/helpers/chat/` (`pure.mjs`, `dom.mjs`, `damage.mjs`, `handlers.mjs`) with unit tests for pure damage/wound helpers; native `document.body` click delegation replaces jQuery listeners.
 - **Actor sheet modules (PR9):** `reload.mjs`, `item-actions.mjs`, `weapon-gates.mjs`, `actor-drops.mjs`, and `sheet-helpers.mjs` with pure drop helpers in `actor-drops-pure.mjs` (unit tested).
 - **Actor sheet modules (PR10):** `stat-rolls.mjs`, `sheet-rolls.mjs`, `sheet-actions.mjs`, and `sheet-actions-pure.mjs` for stat checks and delegated sheet UI clicks/changes.
+- **Actor sheet E2E regression:** `tests/e2e/regression-actor-sheets.spec.js` covers character sheet layout, tab navigation, stat roll chat output, and active-effect stat bonuses (legacy and Foundry v14 ADD modes).
+- **Active effect derived data:** `module/documents/derived/active-effects.mjs` with unit tests for ADD mode resolution across Foundry v10–v14.
 
 ### Changed
 
@@ -35,6 +37,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - **Toxicant item type:** Register `SlaToxicantData` in `CONFIG.Item.dataModels` (was declared in `system.json` but missing from init).
+- **Active effect stat bonuses (Foundry v14):** `SlaActor` derived data now accepts both legacy `ACTIVE_EFFECT_MODES.ADD` (mode `2`) and v14 `ACTIVE_EFFECT_CHANGE_TYPES.add` (mode `20`) when summing core stat bonuses.
+- **E2E (Foundry v14.363):** `regression-sla` settings navigation and `ACTIVE_EFFECT_CHANGE_TYPES` smoke check aligned with current Foundry UI and constant casing.
 
 ### Removed
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -5,6 +5,11 @@ import {
     computeEffectiveArmorPv,
     computeEncumbranceState
 } from './derived/encumbrance.mjs';
+import {
+    effectChangeRows,
+    resolveActiveEffectAddModes,
+    sumActiveEffectAddsForStat
+} from './derived/active-effects.mjs';
 import { applyStatPenalties } from './derived/penalties.mjs';
 import { countWounds, deriveLogicConditions } from './derived/wounds.mjs';
 
@@ -19,10 +24,7 @@ export class SlaActor extends Actor {
      * @returns {EffectChangeData[]}
      */
     static _effectChangeRows(effect) {
-        const root = effect?.changes;
-        if (Array.isArray(root) && root.length) return root;
-        const nested = effect?.system?.changes;
-        return Array.isArray(nested) ? nested : [];
+        return effectChangeRows(effect);
     }
 
     /**
@@ -31,19 +33,8 @@ export class SlaActor extends Actor {
      * @param {string} statKey  str, dex, know, conc, cha, cool
      */
     _sumActiveEffectAddsForCoreStat(statKey) {
-        // v14+: ACTIVE_EFFECT_MODES is deprecated; use ACTIVE_EFFECT_CHANGE_TYPES.
-        const addMode = globalThis.CONST?.ACTIVE_EFFECT_CHANGE_TYPES?.ADD ?? 2;
-        const kb = `system.stats.${statKey}.bonus`;
-        const kv = `system.stats.${statKey}.value`;
-        let sum = 0;
-        for (const effect of this.effects ?? []) {
-            if (effect.disabled) continue;
-            for (const ch of SlaActor._effectChangeRows(effect)) {
-                if (ch.mode !== addMode) continue;
-                if (ch.key === kb || ch.key === kv) sum += Number(ch.value) || 0;
-            }
-        }
-        return sum;
+        const addModes = resolveActiveEffectAddModes();
+        return sumActiveEffectAddsForStat(this.effects, statKey, addModes);
     }
 
     /** @override */

--- a/module/documents/derived/active-effects.mjs
+++ b/module/documents/derived/active-effects.mjs
@@ -1,0 +1,55 @@
+/**
+ * Pure active effect helpers for actor derived data (no document runtime).
+ */
+
+/**
+ * Active effect change rows (Foundry 14 may store under effect.system.changes).
+ * @param {object} effect
+ * @returns {Array<{ key: string, mode: number, value: unknown }>}
+ */
+export function effectChangeRows(effect) {
+    const root = effect?.changes;
+    if (Array.isArray(root) && root.length) return root;
+    const nested = effect?.system?.changes;
+    return Array.isArray(nested) ? nested : [];
+}
+
+/**
+ * All numeric mode values that represent ADD across Foundry v10–v14.
+ * @param {{ ACTIVE_EFFECT_CHANGE_TYPES?: Record<string, number>, ACTIVE_EFFECT_MODES?: Record<string, number> }} [constants]
+ * @returns {Set<number>}
+ */
+export function resolveActiveEffectAddModes(constants = globalThis.CONST) {
+    const types = constants?.ACTIVE_EFFECT_CHANGE_TYPES;
+    const modes = constants?.ACTIVE_EFFECT_MODES;
+    const candidates = [types?.add, types?.ADD, modes?.ADD, 2];
+    return new Set(candidates.filter((v) => v !== undefined && v !== null));
+}
+
+/**
+ * @param {number} mode
+ * @param {Set<number>} addModes
+ */
+export function isActiveEffectAddMode(mode, addModes) {
+    return addModes.has(mode);
+}
+
+/**
+ * Sum ADD modifiers from enabled effects on system.stats.<key>.bonus or legacy .value.
+ * @param {Array<{ disabled?: boolean, changes?: unknown[], system?: { changes?: unknown[] } }>} effects
+ * @param {string} statKey
+ * @param {Set<number>} addModes
+ */
+export function sumActiveEffectAddsForStat(effects, statKey, addModes) {
+    const kb = `system.stats.${statKey}.bonus`;
+    const kv = `system.stats.${statKey}.value`;
+    let sum = 0;
+    for (const effect of effects ?? []) {
+        if (effect.disabled) continue;
+        for (const ch of effectChangeRows(effect)) {
+            if (!isActiveEffectAddMode(ch.mode, addModes)) continue;
+            if (ch.key === kb || ch.key === kv) sum += Number(ch.value) || 0;
+        }
+    }
+    return sum;
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "watch": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map --watch",
         "test:unit": "node --test --test-concurrency=1 tests/unit/*.test.mjs",
         "test:e2e": "playwright test",
-        "test:e2e:regression": "playwright test tests/e2e/regression-sla.spec.js tests/e2e/regression-item-sheets.spec.js",
+        "test:e2e:regression": "playwright test tests/e2e/regression-sla.spec.js tests/e2e/regression-item-sheets.spec.js tests/e2e/regression-actor-sheets.spec.js",
         "test:e2e:operators": "playwright test tests/e2e/regression-operators.spec.js",
         "test:e2e:ui": "playwright test --ui",
         "test:e2e:headed": "playwright test --headed",

--- a/tests/e2e/fixtures.js
+++ b/tests/e2e/fixtures.js
@@ -104,6 +104,66 @@ async function clickItemSheetTab(sheet, tabId) {
 }
 
 /**
+ * Create a character actor for sheet UI tests.
+ * @param {import('@playwright/test').Page} page
+ * @param {object} [system]
+ * @returns {Promise<string>} actor id
+ */
+async function createTestActor(page, system = {}) {
+    return page.evaluate(async (actorSystem) => {
+        const stamp = Date.now();
+        const [actor] = await Actor.createDocuments([
+            {
+                name: `E2E Actor ${stamp}`,
+                type: 'character',
+                system: actorSystem
+            }
+        ]);
+        return actor.id;
+    }, system);
+}
+
+/**
+ * Render a character actor sheet and return a locator scoped to its window.
+ * @param {import('@playwright/test').Page} page
+ * @param {string} actorId
+ */
+async function openActorSheet(page, actorId) {
+    await page.evaluate(async (id) => {
+        const actor = game.actors.get(id);
+        if (!actor) throw new Error(`Actor ${id} not found`);
+        await actor.sheet.render(true);
+    }, actorId);
+
+    const sheet = page.locator('form.application.sla-industries.actor').last();
+    await sheet.waitFor({ state: 'visible', timeout: 15_000 });
+    return sheet;
+}
+
+/**
+ * Switch actor sheet tabs (App V2 rail uses data-tab anchors).
+ * @param {import('@playwright/test').Locator} sheet
+ * @param {string} tabId
+ */
+async function clickActorSheetTab(sheet, tabId) {
+    await sheet.locator(`nav.sheet-tabs a[data-tab="${tabId}"]`).click();
+}
+
+/**
+ * Delete E2E actors created during tests.
+ * @param {import('@playwright/test').Page} page
+ */
+async function deleteTestActors(page) {
+    await page
+        .evaluate(async () => {
+            for (const actor of game.actors.filter((a) => a.name?.startsWith('E2E Actor '))) {
+                await actor.delete();
+            }
+        })
+        .catch(() => {});
+}
+
+/**
  * Close open Foundry application windows between tests.
  * @param {import('@playwright/test').Page} page
  */
@@ -125,5 +185,9 @@ module.exports = {
     createWorldItem,
     openItemSheet,
     clickItemSheetTab,
+    createTestActor,
+    openActorSheet,
+    clickActorSheetTab,
+    deleteTestActors,
     closeApplicationWindows
 };

--- a/tests/e2e/regression-actor-sheets.spec.js
+++ b/tests/e2e/regression-actor-sheets.spec.js
@@ -1,0 +1,193 @@
+const { test, expect } = require('@playwright/test');
+const {
+    joinGame,
+    waitForSLASystem,
+    dismissFoundryNotifications,
+    createTestActor,
+    openActorSheet,
+    clickActorSheetTab,
+    deleteTestActors,
+    closeApplicationWindows
+} = require('./fixtures');
+
+test.describe.configure({ timeout: 60_000 });
+
+test.describe('SLA actor sheet UI — regression', () => {
+    test.beforeEach(async ({ page }) => {
+        test.skip(!process.env.FOUNDRY_USER, 'Set FOUNDRY_USER');
+        await joinGame(page);
+        await waitForSLASystem(page);
+        const gm = await page.evaluate(() => game.user?.isGM === true);
+        test.skip(!gm, 'Requires GM — use a Gamemaster account for FOUNDRY_USER');
+        await page.evaluate(() => {
+            if (globalThis.game?.paused) globalThis.game.togglePause();
+        });
+        await dismissFoundryNotifications(page);
+    });
+
+    test.afterEach(async ({ page }) => {
+        await deleteTestActors(page);
+        await closeApplicationWindows(page);
+    });
+
+    test('character sheet — stats matrix, tab rail, and stat roll control', async ({ page }) => {
+        const actorId = await createTestActor(page, {
+            stats: { str: { value: 4 }, dex: { value: 3 } }
+        });
+        const sheet = await openActorSheet(page, actorId);
+
+        await expect(sheet.locator('.stats-matrix')).toBeVisible();
+        await expect(sheet.locator('a.rollable[data-roll-type="stat"][data-key="str"]')).toBeVisible();
+        await expect(sheet.locator('nav.sheet-tabs a[data-tab="main"]')).toBeVisible();
+        await expect(sheet.locator('nav.sheet-tabs a[data-tab="combat"]')).toBeVisible();
+        await expect(sheet.locator('nav.sheet-tabs a[data-tab="inventory"]')).toBeVisible();
+        await expect(sheet.locator('nav.sheet-tabs a[data-tab="effects"]')).toBeVisible();
+    });
+
+    test('character sheet — tab navigation shows combat and inventory panels', async ({ page }) => {
+        const actorId = await createTestActor(page);
+        const sheet = await openActorSheet(page, actorId);
+
+        await clickActorSheetTab(sheet, 'combat');
+        await expect(sheet.locator('.tab[data-tab="combat"]')).toHaveClass(/active/);
+
+        await clickActorSheetTab(sheet, 'inventory');
+        await expect(sheet.locator('.tab[data-tab="inventory"]')).toHaveClass(/active/);
+
+        await clickActorSheetTab(sheet, 'effects');
+        await expect(sheet.locator('.tab[data-tab="effects"]')).toHaveClass(/active/);
+    });
+
+    test('character sheet — stat roll posts to chat', async ({ page }) => {
+        const actorId = await createTestActor(page, {
+            stats: { str: { value: 5 } }
+        });
+        const sheet = await openActorSheet(page, actorId);
+
+        await sheet.locator('a.rollable[data-roll-type="stat"][data-key="str"]').click();
+
+        await expect
+            .poll(
+                async () =>
+                    page.evaluate(() =>
+                        globalThis.game?.messages?.contents?.some((m) =>
+                            /STR\s+CHECK/i.test(String(m.content ?? ''))
+                        )
+                    ),
+                { timeout: 15_000 }
+            )
+            .toBe(true);
+        await expect(page.getByRole('heading', { name: /STR\s+CHECK/i }).first()).toBeVisible();
+    });
+});
+
+test.describe('SlaActor derived data — active effect ADD modes', () => {
+    test.beforeEach(async ({ page }) => {
+        test.skip(!process.env.FOUNDRY_USER, 'Set FOUNDRY_USER');
+        await joinGame(page);
+        await waitForSLASystem(page);
+        const gm = await page.evaluate(() => game.user?.isGM === true);
+        test.skip(!gm, 'Requires GM — use a Gamemaster account for FOUNDRY_USER');
+    });
+
+    test('v14 ADD change type (mode 20) increases core stat total', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const stamp = Date.now();
+            const [actor] = await Actor.createDocuments([
+                {
+                    name: `E2E Actor v14 AE ${stamp}`,
+                    type: 'character',
+                    system: { stats: { str: { value: 3, bonus: 0 } } }
+                }
+            ]);
+            await actor.createEmbeddedDocuments('ActiveEffect', [
+                {
+                    name: 'STR Boost v14',
+                    disabled: false,
+                    changes: [
+                        {
+                            key: 'system.stats.str.bonus',
+                            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+                            value: 2
+                        }
+                    ]
+                }
+            ]);
+            const total = actor.system.stats.str.total;
+            await actor.delete();
+            return total;
+        });
+        expect(result).toBe(5);
+    });
+
+    test('legacy ADD change type (mode 2) increases core stat total', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const stamp = Date.now();
+            const [actor] = await Actor.createDocuments([
+                {
+                    name: `E2E Actor legacy AE ${stamp}`,
+                    type: 'character',
+                    system: { stats: { str: { value: 3, bonus: 0 } } }
+                }
+            ]);
+            await actor.createEmbeddedDocuments('ActiveEffect', [
+                {
+                    name: 'STR Boost legacy',
+                    disabled: false,
+                    changes: [
+                        {
+                            key: 'system.stats.str.bonus',
+                            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                            value: 2
+                        }
+                    ]
+                }
+            ]);
+            const total = actor.system.stats.str.total;
+            await actor.delete();
+            return total;
+        });
+        expect(result).toBe(5);
+    });
+
+    test('mixed v14 and legacy ADD modes stack on the same stat', async ({ page }) => {
+        const result = await page.evaluate(async () => {
+            const stamp = Date.now();
+            const [actor] = await Actor.createDocuments([
+                {
+                    name: `E2E Actor mixed AE ${stamp}`,
+                    type: 'character',
+                    system: { stats: { str: { value: 3, bonus: 0 } } }
+                }
+            ]);
+            await actor.createEmbeddedDocuments('ActiveEffect', [
+                {
+                    name: 'V14 boost',
+                    disabled: false,
+                    changes: [
+                        {
+                            key: 'system.stats.str.bonus',
+                            mode: CONST.ACTIVE_EFFECT_CHANGE_TYPES.add,
+                            value: 2
+                        }
+                    ]
+                },
+                {
+                    name: 'Legacy boost',
+                    disabled: false,
+                    changes: [
+                        {
+                            key: 'system.stats.str.bonus',
+                            mode: CONST.ACTIVE_EFFECT_MODES.ADD,
+                            value: 1
+                        }
+                    ]
+                }
+            ]);
+            const total = actor.system.stats.str.total;
+            await actor.delete();
+            return total;
+        });
+        expect(result).toBe(6);
+    });
+});

--- a/tests/e2e/regression-sla.spec.js
+++ b/tests/e2e/regression-sla.spec.js
@@ -10,6 +10,9 @@ test.describe('SLA regression — authenticated', () => {
         needsAuth();
         await joinGame(page);
         await waitForSLASystem(page);
+        await page.evaluate(() => {
+            if (globalThis.game?.paused) globalThis.game.togglePause();
+        });
     });
 
     test('game.system is sla-industries with expected version shape', async ({ page }) => {
@@ -53,15 +56,32 @@ test.describe('SLA regression — authenticated', () => {
     test('Foundry v14+ Active Effect change types are available (effect stack smoke)', async ({ page }) => {
         const ok = await page.evaluate(() => {
             const t = globalThis.CONST?.ACTIVE_EFFECT_CHANGE_TYPES;
-            const add = t?.ADD;
+            const add = t?.add ?? t?.ADD;
             return Boolean(t && typeof t === 'object' && add !== undefined && add !== null);
         });
         expect(ok).toBe(true);
     });
 
+    test('SlaActor and SlaItem are registered with legacy aliases', async ({ page }) => {
+        const classes = await page.evaluate(() => ({
+            slaActor: globalThis.game?.sla?.SlaActor?.name,
+            slaItem: globalThis.game?.sla?.SlaItem?.name,
+            legacyActor: globalThis.game?.boilerplate?.BoilerplateActor?.name,
+            legacyItem: globalThis.game?.boilerplate?.BoilerplateItem?.name,
+            configActor: globalThis.CONFIG?.Actor?.documentClass?.name,
+            configItem: globalThis.CONFIG?.Item?.documentClass?.name
+        }));
+        expect(classes.slaActor).toBe('SlaActor');
+        expect(classes.slaItem).toBe('SlaItem');
+        expect(classes.legacyActor).toBe('SlaActor');
+        expect(classes.legacyItem).toBe('SlaItem');
+        expect(classes.configActor).toBe('SlaActor');
+        expect(classes.configItem).toBe('SlaItem');
+    });
+
     test('Configure Settings lists SLA Industries section', async ({ page }) => {
         await dismissFoundryNotifications(page);
-        await page.getByRole('tab', { name: /game settings/i }).click();
+        await page.getByRole('tab', { name: /^settings$/i }).click();
         await page.getByRole('button', { name: /^game settings$/i }).click();
         await page.getByRole('button', { name: /SLA Industries 2nd Edition/i }).click();
         await expect(page.getByText(/Enable Combat Movement Lock/i).first()).toBeVisible({ timeout: 15_000 });

--- a/tests/unit/derived-active-effects.test.mjs
+++ b/tests/unit/derived-active-effects.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for active effect ADD mode resolution (no Foundry runtime).
+ */
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    effectChangeRows,
+    resolveActiveEffectAddModes,
+    sumActiveEffectAddsForStat
+} from '../../module/documents/derived/active-effects.mjs';
+
+describe('effectChangeRows', () => {
+    test('prefers top-level changes array', () => {
+        const rows = [{ key: 'system.stats.str.bonus', mode: 2, value: 1 }];
+        assert.deepEqual(effectChangeRows({ changes: rows, system: { changes: [] } }), rows);
+    });
+
+    test('falls back to system.changes when root is empty', () => {
+        const rows = [{ key: 'system.stats.dex.bonus', mode: 20, value: 2 }];
+        assert.deepEqual(effectChangeRows({ changes: [], system: { changes: rows } }), rows);
+    });
+});
+
+describe('resolveActiveEffectAddModes', () => {
+    test('includes v14 lowercase add and legacy ADD modes', () => {
+        const modes = resolveActiveEffectAddModes({
+            ACTIVE_EFFECT_CHANGE_TYPES: { add: 20 },
+            ACTIVE_EFFECT_MODES: { ADD: 2 }
+        });
+        assert.equal(modes.has(20), true);
+        assert.equal(modes.has(2), true);
+    });
+
+    test('falls back to legacy mode 2 when CONST is missing', () => {
+        const modes = resolveActiveEffectAddModes(undefined);
+        assert.equal(modes.has(2), true);
+    });
+});
+
+describe('sumActiveEffectAddsForStat', () => {
+    const addModes = new Set([2, 20]);
+
+    test('sums bonus key rows with legacy ADD mode 2', () => {
+        const sum = sumActiveEffectAddsForStat(
+            [
+                {
+                    disabled: false,
+                    changes: [{ key: 'system.stats.str.bonus', mode: 2, value: 3 }]
+                }
+            ],
+            'str',
+            addModes
+        );
+        assert.equal(sum, 3);
+    });
+
+    test('sums bonus key rows with v14 ADD mode 20', () => {
+        const sum = sumActiveEffectAddsForStat(
+            [
+                {
+                    disabled: false,
+                    changes: [{ key: 'system.stats.str.bonus', mode: 20, value: 4 }]
+                }
+            ],
+            'str',
+            addModes
+        );
+        assert.equal(sum, 4);
+    });
+
+    test('sums legacy value key rows', () => {
+        const sum = sumActiveEffectAddsForStat(
+            [
+                {
+                    disabled: false,
+                    changes: [{ key: 'system.stats.dex.value', mode: 2, value: 1 }]
+                }
+            ],
+            'dex',
+            addModes
+        );
+        assert.equal(sum, 1);
+    });
+
+    test('ignores disabled effects and non-ADD modes', () => {
+        const sum = sumActiveEffectAddsForStat(
+            [
+                {
+                    disabled: true,
+                    changes: [{ key: 'system.stats.str.bonus', mode: 2, value: 9 }]
+                },
+                {
+                    disabled: false,
+                    changes: [{ key: 'system.stats.str.bonus', mode: 50, value: 9 }]
+                },
+                {
+                    disabled: false,
+                    changes: [{ key: 'system.stats.conc.bonus', mode: 20, value: 2 }]
+                }
+            ],
+            'str',
+            addModes
+        );
+        assert.equal(sum, 0);
+    });
+
+    test('sums multiple enabled ADD rows', () => {
+        const sum = sumActiveEffectAddsForStat(
+            [
+                {
+                    disabled: false,
+                    changes: [
+                        { key: 'system.stats.cool.bonus', mode: 2, value: 1 },
+                        { key: 'system.stats.cool.bonus', mode: 20, value: 2 }
+                    ]
+                }
+            ],
+            'cool',
+            addModes
+        );
+        assert.equal(sum, 3);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Foundry v14 compatibility for core stat bonuses from active effects, aligns flaky `regression-sla` tests with v14.363 UI, and adds actor sheet Playwright coverage.

## Active effect compat fix

Foundry v14.363 stores ADD changes with `CONST.ACTIVE_EFFECT_CHANGE_TYPES.add` (mode **20**), while older effects use `ACTIVE_EFFECT_MODES.ADD` (mode **2**). `SlaActor._sumActiveEffectAddsForCoreStat` only matched mode 2, so v14-created effects did not increase stat totals.

**Solution:** Pure helpers in `module/documents/derived/active-effects.mjs`:
- `resolveActiveEffectAddModes()` — collects all valid ADD mode values (2, 20, etc.)
- `sumActiveEffectAddsForStat()` — sums bonus/value rows for any matching ADD mode

9 unit tests in `tests/unit/derived-active-effects.test.mjs`.

## E2E coverage added

New `tests/e2e/regression-actor-sheets.spec.js` (6 tests):

| Test | What it verifies |
|------|------------------|
| Stats matrix + tab rail | Character sheet layout after PR9–10 extraction |
| Tab navigation | Combat, inventory, effects panels activate |
| Stat roll → chat | STR roll button posts a chat message via `sheet-rolls`/`stat-rolls` |
| v14 ADD mode 20 | `str.total` = base + bonus from v14 effect |
| Legacy ADD mode 2 | Same for migrated/legacy effects |
| Mixed modes | Both stack on the same stat (base 3 + 2 + 1 = 6) |

Also updates `regression-sla.spec.js` for v14 Settings tab label, game unpause, and lowercase `add` constant.

Actor sheet helpers added to `tests/e2e/fixtures.js`. `npm run test:e2e:regression` now includes the actor sheet spec.

## Verification

```
npm run test:unit   # 106/106 passed
npm run test:e2e    # 33/33 passed (Foundry v14.363)
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-166bebf7-53a8-4635-a81b-97baad83c205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-166bebf7-53a8-4635-a81b-97baad83c205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

