### PR TITLE
fix: restore chat card click handlers (v2.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.7.1] - 2026-06-08
+
+### Fixed
+
+- **Chat card buttons (adjust TN, Luck, damage, etc.):** Native click delegation no longer spreads the DOM `Event` (which drops `preventDefault`), so GM difficulty adjustment and other chat card actions work again after the v2.7.0 chat refactor.
+- **Adjust TN tooltip:** Difficulty recalculation uses `generateDiceTooltip()` instead of `roll.getTooltip()` so skill-check cards re-render consistently.
+
+### Added
+
+- **Unit tests:** `chat-dom.test.mjs` (handler event wrapper, data-tn reads) and `chat-difficulty.test.mjs` (TN recalculation and tooltip regeneration).
+
 ## [2.7.0] - 2026-06-08
 
 ### Added

--- a/module/helpers/chat.mjs
+++ b/module/helpers/chat.mjs
@@ -1,5 +1,5 @@
 import { executeStandardDamageRoll, resolveDamageDisplay } from './chat/damage.mjs';
-import { setButtonDisabled } from './chat/dom.mjs';
+import { handlerEvent, setButtonDisabled } from './chat/dom.mjs';
 import {
     onApplyDamage,
     onApplyEbbEffects,
@@ -71,20 +71,22 @@ export class SLAChat {
             const el = target.closest(CHAT_CLICK_SELECTOR);
             if (!el) return;
 
+            const handlerEv = handlerEvent(ev, el);
+
             if (el.matches('.chat-btn-wound, .chat-btn-damage, .damage-roll')) {
-                void onRollDamage({ ...ev, currentTarget: el });
+                void onRollDamage(handlerEv);
             } else if (el.matches('.apply-damage-btn')) {
-                void onApplyDamage({ ...ev, currentTarget: el });
+                void onApplyDamage(handlerEv);
             } else if (el.matches('.sla-ebb-apply-effect-btn')) {
-                void onApplyEbbEffects({ ...ev, currentTarget: el });
+                void onApplyEbbEffects(handlerEv);
             } else if (el.matches('.sla-ebb-remove-wounds-btn')) {
-                void onRemoveEbbWounds({ ...ev, currentTarget: el });
+                void onRemoveEbbWounds(handlerEv);
             } else if (el.matches('.roll-toggle')) {
-                onToggleRoll({ ...ev, currentTarget: el });
+                onToggleRoll(handlerEv);
             } else if (el.matches('.chat-btn-luck')) {
-                void onLuck({ ...ev, currentTarget: el });
+                void onLuck(handlerEv);
             } else if (el.matches('.diff-btn')) {
-                void onChangeDifficulty({ ...ev, currentTarget: el });
+                void onChangeDifficulty(handlerEv);
             }
         };
 

--- a/module/helpers/chat/dom.mjs
+++ b/module/helpers/chat/dom.mjs
@@ -58,3 +58,18 @@ export function toggleTooltip(tooltip) {
     if (hidden) tooltip.removeAttribute('hidden');
     else tooltip.setAttribute('hidden', '');
 }
+
+/**
+ * Build a handler-friendly event object from a native DOM event.
+ * Spreading a native Event drops prototype methods such as preventDefault.
+ *
+ * @param {Event} nativeEv
+ * @param {HTMLElement} currentTarget
+ */
+export function handlerEvent(nativeEv, currentTarget) {
+    return {
+        currentTarget,
+        preventDefault: () => nativeEv.preventDefault(),
+        stopPropagation: () => nativeEv.stopPropagation()
+    };
+}

--- a/module/helpers/chat/handlers.mjs
+++ b/module/helpers/chat/handlers.mjs
@@ -1,5 +1,5 @@
 import { LuckDialog } from '../../apps/luck-dialog.mjs';
-import { calculateRollResult } from '../dice.mjs';
+import { calculateRollResult, generateDiceTooltip } from '../dice.mjs';
 import { syncEbbCriticalFlux } from '../ebb-flux.mjs';
 import { normalizeEbbEffect } from '../items.mjs';
 import { resolveEbbOutcomeText, resolveWeaponMosOutcome } from '../../sheets/actor/roll-math.mjs';
@@ -473,7 +473,7 @@ export async function onChangeDifficulty(ev) {
             resultColor: resultColor,
             itemName: flags.itemName,
             successTotal: result.total,
-            tooltip: await roll.getTooltip(),
+            tooltip: generateDiceTooltip(roll, flags.baseModifier, 0, flags.successDieModifier || 0),
             skillDice: result.skillDiceData,
             notes: finalNotes,
             showDamageButton: showButton,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sla-industries",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sla-industries",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "license": "MIT",
             "devDependencies": {
                 "@playwright/test": "^1.49.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sla-industries",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "description": "CSS compiler for the SLA Industries system",
     "scripts": {
         "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "sla-industries",
     "title": "SLA Industries 2nd Edition",
     "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "compatibility": {
         "minimum": "14",
         "verified": "14.360"
@@ -46,7 +46,7 @@
     ],
     "url": "https://github.com/VacantFanatic/sla-foundry",
     "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.7.0/sla-industries.zip",
+    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.7.1/sla-industries.zip",
     "packs": [
         {
             "name": "skills",

--- a/tests/unit/chat-difficulty.test.mjs
+++ b/tests/unit/chat-difficulty.test.mjs
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for GM difficulty (TN) recalculation helpers used by onChangeDifficulty.
+ */
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { calculateRollResult, generateDiceTooltip } from '../../module/helpers/dice.mjs';
+import { buildDifficultyNotes, rebuildDifficultyDamageFormula } from '../../module/helpers/chat/pure.mjs';
+
+/** Minimal roll shape matching createSLARoll output after evaluate. */
+function mockSkillRoll({ sdRaw = 8, skillRaw = [6, 9] } = {}) {
+    return {
+        terms: [{ results: [{ result: sdRaw }] }, { results: [] }, { results: skillRaw.map((result) => ({ result })) }],
+        autoSkillSuccesses: 0
+    };
+}
+
+describe('skill roll TN adjustment', () => {
+    test('recalculates success against new TN', () => {
+        const roll = mockSkillRoll({ sdRaw: 8 });
+        const baseModifier = 2;
+        const at10 = calculateRollResult(roll, baseModifier, 10);
+        const at13 = calculateRollResult(roll, baseModifier, 13);
+        assert.equal(at10.isSuccess, true);
+        assert.equal(at10.total, 10);
+        assert.equal(at13.isSuccess, false);
+        assert.equal(at13.total, 10);
+    });
+
+    test('builds difficulty notes from flags TN', () => {
+        const notes = buildDifficultyNotes('Perception', 10, 7);
+        assert.equal(notes, 'Perception (TN 10 → 7)');
+    });
+
+    test('regenerates tooltip HTML for updated card content', () => {
+        const roll = mockSkillRoll({ sdRaw: 8, skillRaw: [6, 9] });
+        const html = generateDiceTooltip(roll, 2);
+        assert.match(html, /Success Die/);
+        assert.match(html, /dice-tooltip/);
+        assert.match(html, /<strong>10<\/strong>/);
+    });
+
+    test('rebuilds damage formula when MOS bonus changes with TN', () => {
+        const formula = rebuildDifficultyDamageFormula('2d10', 1, 2);
+        assert.equal(formula, '2d10 + 3');
+    });
+});

--- a/tests/unit/chat-dom.test.mjs
+++ b/tests/unit/chat-dom.test.mjs
@@ -1,0 +1,47 @@
+/**
+ * Unit tests for chat DOM helpers (no Foundry runtime).
+ */
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { handlerEvent, readDataNumber, readDataString } from '../../module/helpers/chat/dom.mjs';
+
+describe('handlerEvent', () => {
+    test('exposes preventDefault and stopPropagation from the native event', () => {
+        let prevented = false;
+        let stopped = false;
+        const nativeEv = {
+            preventDefault: () => {
+                prevented = true;
+            },
+            stopPropagation: () => {
+                stopped = true;
+            }
+        };
+        const target = { tagName: 'BUTTON' };
+        const handlerEv = handlerEvent(nativeEv, target);
+
+        assert.equal(handlerEv.currentTarget, target);
+        handlerEv.preventDefault();
+        handlerEv.stopPropagation();
+        assert.equal(prevented, true);
+        assert.equal(stopped, true);
+    });
+
+    test('spread native Event does not provide preventDefault (regression guard)', () => {
+        const nativeEv = new Event('click');
+        const broken = { ...nativeEv, currentTarget: {} };
+        assert.equal(typeof broken.preventDefault, 'undefined');
+        assert.equal(typeof handlerEvent(nativeEv, {}).preventDefault, 'function');
+    });
+});
+
+describe('readDataString / readDataNumber', () => {
+    test('reads data-tn from diff buttons', () => {
+        const btn = {
+            dataset: { tn: '13' },
+            getAttribute: (name) => (name === 'data-tn' ? '13' : null)
+        };
+        assert.equal(readDataString(btn, 'tn'), '13');
+        assert.equal(readDataNumber(btn, 'tn', 10), 13);
+    });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #299 — clicking **Adjust TN** (and other chat card buttons) threw `preventDefault is not a function` after the v2.7.0 chat refactor.

The native click delegation used `{ ...ev, currentTarget: el }`, but spreading a DOM `Event` does not copy prototype methods such as `preventDefault`. Every chat card handler that called `ev.preventDefault()` failed.

## Changes

- Add `handlerEvent()` in `module/helpers/chat/dom.mjs` to forward `preventDefault` / `stopPropagation` from the native event.
- Route all chat card click handlers through `handlerEvent()` in `module/helpers/chat.mjs`.
- Use `generateDiceTooltip()` when GM recalculates difficulty so skill-check cards re-render reliably.
- Add unit tests: `chat-dom.test.mjs`, `chat-difficulty.test.mjs`.
- Release **v2.7.1** (changelog, `package.json`, `system.json` download URL).

## Test plan

- [x] `npm run test:unit` (113 tests pass)
- [ ] In Foundry: skill check chat card → GM clicks Adjust TN buttons → card updates without console error
- [ ] Luck, damage roll, and roll-toggle buttons on chat cards still work
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc49f3e4-b03e-433b-afdb-34e3fa72e7de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc49f3e4-b03e-433b-afdb-34e3fa72e7de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

