### PR TITLE
Actor sheet density pass (v2.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **Actor sheet density pass:** Compact header (species/package grid, shorter finance inputs), icon-only tab rail with subtle active state (no oversized orange tiles), smaller wound checkboxes/labels, icon-only Manage XP button, and looser spacing between condition toggles.
+- **Actor sheet density pass:** Compact header (species/package grid, shorter finance inputs), icon-only tab rail with subtle active state (no oversized orange tiles), smaller wound checkboxes/labels, icon-only Manage XP button, looser spacing between condition toggles, and a subtler Active Effects add control.
 - **Tab rail:** Removed persistent text labels under icons; tooltips and `aria-label` remain for discoverability.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- **Actor sheet density pass:** Compact header (species/package grid, shorter finance inputs), icon-only tab rail with subtle active state (no oversized orange tiles), and smaller wound/condition controls.
+- **Actor sheet density pass:** Compact header (species/package grid, shorter finance inputs), icon-only tab rail with subtle active state (no oversized orange tiles), smaller wound checkboxes/labels, icon-only Manage XP button, and looser spacing between condition toggles.
 - **Tab rail:** Removed persistent text labels under icons; tooltips and `aria-label` remain for discoverability.
 
 ### Added
 
+- **HP clamping:** `clampHpValue` enforces HP within `[0, max]` on sheet edit, document `_preUpdate`, and when derived max drops below stored HP.
 - **Screenshot capture spec:** `tests/e2e/capture-actor-sheet-screenshots.spec.js` exports header, stats, tab rail, wounds, and full sheet PNGs for UX review.
 
 ## [2.8.0] - 2026-06-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.8.1] - 2026-06-08
+
+### Changed
+
+- **Actor sheet density pass:** Compact header (species/package grid, shorter finance inputs), icon-only tab rail with subtle active state (no oversized orange tiles), and smaller wound/condition controls.
+- **Tab rail:** Removed persistent text labels under icons; tooltips and `aria-label` remain for discoverability.
+
+### Added
+
+- **Screenshot capture spec:** `tests/e2e/capture-actor-sheet-screenshots.spec.js` exports header, stats, tab rail, wounds, and full sheet PNGs for UX review.
+
 ## [2.8.0] - 2026-06-08
 
 ### Added

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -11,6 +11,7 @@ import {
     sumActiveEffectAddsForStat
 } from './derived/active-effects.mjs';
 import { applyStatPenalties } from './derived/penalties.mjs';
+import { clampHpValue } from '../sheets/actor/sheet-ux-pure.mjs';
 import { countWounds, deriveLogicConditions } from './derived/wounds.mjs';
 
 /**
@@ -628,13 +629,12 @@ export class SlaActor extends Actor {
     async _preUpdate(changed, options, user) {
         await super._preUpdate(changed, options, user);
 
-        // HP Floor & Ceiling
+        // HP floor & ceiling (value edits and max drops that leave stored HP above max)
         if (changed.system?.hp?.value !== undefined) {
-            const maxHp = this.system.hp.max || 0;
-            let val = changed.system.hp.value;
-            if (val < 0) val = 0;
-            if (val > maxHp) val = maxHp;
-            changed.system.hp.value = val;
+            const maxHp = changed.system?.hp?.max ?? this.system.hp.max ?? 0;
+            changed.system.hp.value = clampHpValue(changed.system.hp.value, maxHp);
+        } else if (changed.system?.hp?.max !== undefined) {
+            changed.system.hp.value = clampHpValue(this.system.hp.value, changed.system.hp.max);
         }
 
         // Luck & Flux Clamping
@@ -738,6 +738,15 @@ export class SlaActor extends Actor {
             await super._onUpdate(changed, options, userId);
         } catch (error) {
             console.error('SLA Industries | Error in super._onUpdate:', error);
+        }
+
+        // Derived max can fall below stored HP (e.g. STR drop); clamp once without looping.
+        if (!options.slaHpClamp) {
+            const clamped = clampHpValue(this.system.hp?.value, this.system.hp?.max);
+            if (clamped !== (Number(this.system.hp?.value) || 0)) {
+                await this.update({ 'system.hp.value': clamped }, { slaHpClamp: true });
+                return;
+            }
         }
 
         // 1. STOP if the update didn't touch conditions OR wounds.

--- a/module/sheets/actor/sheet-actions.mjs
+++ b/module/sheets/actor/sheet-actions.mjs
@@ -4,6 +4,7 @@ import { onItemCreate } from './actor-drops.mjs';
 import { onReloadWeapon } from './reload.mjs';
 import { useDrugItem } from './item-actions.mjs';
 import { executeCombatLoadoutDamageRoll } from './weapon-gates.mjs';
+import { clampHpValue } from './sheet-ux-pure.mjs';
 import { buildSpeciesRemovalUpdates } from './sheet-actions-pure.mjs';
 import { handleSheetRoll } from './sheet-rolls.mjs';
 
@@ -275,6 +276,16 @@ export async function handleSheetChange(sheet, event) {
         const item = sheet.actor.items.get(itemId);
         const field = input.dataset.field;
         if (item && field) await item.update({ [field]: Number(input.value) });
+        return;
+    }
+
+    const hpInput = el.closest('input[name="system.hp.value"]');
+    if (hpInput instanceof HTMLInputElement) {
+        const max = sheet.actor.system.hp?.max ?? 0;
+        const clamped = clampHpValue(hpInput.value, max);
+        if (String(clamped) !== hpInput.value) {
+            hpInput.value = String(clamped);
+        }
         return;
     }
 

--- a/module/sheets/actor/sheet-ux-pure.mjs
+++ b/module/sheets/actor/sheet-ux-pure.mjs
@@ -32,6 +32,21 @@ export function statPlayColorClass(total, base) {
 }
 
 /**
+ * Clamp stored HP to [0, max]. When max is 0, HP is forced to 0.
+ * @param {number | string} value
+ * @param {number | string} max
+ * @returns {number}
+ */
+export function clampHpValue(value, max) {
+    let v = Number(value) || 0;
+    const m = Number(max) || 0;
+    if (v < 0) v = 0;
+    if (m > 0 && v > m) v = m;
+    else if (m <= 0) v = 0;
+    return v;
+}
+
+/**
  * @param {number} value
  * @param {number} max
  * @returns {{ percent: number, tone: HpBarTone }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sla-industries",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "description": "CSS compiler for the SLA Industries system",
     "scripts": {
         "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",

--- a/src/scss/sheets/actor/_density.scss
+++ b/src/scss/sheets/actor/_density.scss
@@ -1,0 +1,202 @@
+/**
+ * Actor sheet density pass — tighten oversized header, tab rail, and wounds UI.
+ */
+
+/* --- Header -------------------------------------------------------------- */
+.sla-sheet .header-grid {
+    min-height: 132px;
+}
+
+.sla-sheet .header-left {
+    padding: 6px;
+}
+
+.sla-sheet .header-fields {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+    align-items: start;
+}
+
+.sla-sheet .header-fields .form-group {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 3px;
+}
+
+.sla-sheet .header-fields .form-group label.label-bold {
+    flex: 0 0 auto;
+    font-size: 0.7rem;
+}
+
+.sla-sheet .header-bottom-bar {
+    margin-top: 4px;
+    padding-top: 4px;
+    font-size: 0.8rem;
+}
+
+.sla-sheet .finance-box {
+    flex: 0 0 118px;
+    max-width: 132px;
+}
+
+.sla-sheet .sla-finance-details summary {
+    font-size: 0.7rem;
+    padding: 3px 4px;
+}
+
+.sla-sheet .sla-finance-fields {
+    gap: 4px;
+    padding: 4px 6px 6px;
+}
+
+.sla-sheet .sla-finance-fields .sla-field > label {
+    font-size: 0.65rem;
+    margin-bottom: 0;
+}
+
+.sla-sheet .sla-finance-fields input[type='number'] {
+    height: 22px;
+    min-height: 22px;
+    padding: 1px 5px;
+    font-size: 0.8rem;
+    line-height: 1.2;
+}
+
+.sla-sheet .chip,
+.sla-sheet .chip-placeholder {
+    height: 26px;
+    min-height: 26px;
+    font-size: 0.78rem;
+}
+
+.sla-sheet .chip img {
+    flex: 0 0 20px;
+    width: 20px;
+    height: 20px;
+}
+
+.sla-sheet .portrait-container {
+    flex: 0 0 108px;
+}
+
+/* --- Tab rail ------------------------------------------------------------ */
+.sla-sheet .sheet-tabs.sla-sheet-tab-rail {
+    width: 34px;
+    padding: 4px 2px;
+    gap: 2px;
+    overflow: visible;
+    overflow-y: visible;
+    flex-shrink: 0;
+    border-bottom: none;
+}
+
+.sla-sheet .sheet-tabs.sla-sheet-tab-rail .item,
+.sla-sheet .sheet-tabs.sla-sheet-tab-rail .sla-tab-rail-btn {
+    width: 30px;
+    height: 30px;
+    min-width: 30px;
+    min-height: 30px;
+    max-height: 30px;
+    padding: 0;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    flex-direction: column;
+}
+
+.sla-sheet .sheet-tabs.sla-sheet-tab-rail .sla-tab-rail-btn i {
+    font-size: 0.85rem;
+    line-height: 1;
+}
+
+/* Icon-only rail: compact active — not a full-height orange tile */
+.sla-sheet .sheet-tabs.sla-sheet-tab-rail .item.active {
+    color: var(--sla-accent);
+    background: rgba(208, 94, 26, 0.12);
+    border-color: var(--sla-accent);
+    box-shadow: none;
+}
+
+.sla-sheet .sheet-tabs.sla-sheet-tab-rail .item:hover {
+    color: var(--sla-text-light);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.sla-sheet .sheet-tabs.sla-sheet-tab-rail .sla-tab-rail-label {
+    display: none !important;
+}
+
+.sla-sheet .sheet-tabs.sla-sheet-tab-rail .sla-tab-rail-tooltip {
+    font-size: 0.68rem;
+    padding: 2px 6px;
+}
+
+/* --- Wounds & conditions ------------------------------------------------- */
+.sla-sheet .wound-list {
+    gap: 4px;
+    margin-bottom: 6px;
+}
+
+.sla-sheet .wound-entry {
+    padding: 2px 6px;
+    min-height: 0;
+
+    label {
+        font-size: 0.72rem;
+        font-weight: 600;
+    }
+
+    .wound-checkbox {
+        width: 14px !important;
+        height: 14px !important;
+        min-width: 14px !important;
+        min-height: 14px !important;
+    }
+}
+
+.sla-sheet .sla-wound-panel {
+    gap: 8px;
+}
+
+.sla-sheet .sla-wound-diagram {
+    min-width: 96px;
+    padding: 4px;
+    gap: 3px;
+}
+
+.sla-sheet .sla-wound-diagram__slot {
+    width: 28px;
+    height: 22px;
+    font-size: 0.58rem;
+}
+
+.sla-sheet .condition-grid {
+    gap: 4px;
+    padding-top: 6px;
+    justify-content: flex-start;
+}
+
+.sla-sheet .condition-toggle {
+    width: 34px;
+    height: 34px;
+    min-width: 34px;
+    min-height: 34px;
+    max-width: 34px;
+    max-height: 34px;
+    font-size: 1rem;
+    flex: 0 0 34px;
+}
+
+.sla-sheet .sla-wound-summary {
+    font-size: 0.72rem;
+    margin-bottom: 4px;
+}
+
+/* --- Stat mode banner ---------------------------------------------------- */
+.sla-sheet .sla-stat-mode-banner {
+    margin: 0 5px 2px;
+    padding: 2px 6px;
+    font-size: 0.68rem;
+    line-height: 1.3;
+}

--- a/src/scss/sheets/actor/_density.scss
+++ b/src/scss/sheets/actor/_density.scss
@@ -139,19 +139,22 @@
 }
 
 .sla-sheet .wound-entry {
-    padding: 2px 6px;
+    padding: 1px 4px;
     min-height: 0;
+    gap: 4px;
 
     label {
-        font-size: 0.72rem;
+        font-size: 0.62rem;
         font-weight: 600;
+        line-height: 1.1;
     }
 
     .wound-checkbox {
-        width: 14px !important;
-        height: 14px !important;
-        min-width: 14px !important;
-        min-height: 14px !important;
+        width: 12px !important;
+        height: 12px !important;
+        min-width: 12px !important;
+        min-height: 12px !important;
+        margin: 0;
     }
 }
 
@@ -172,20 +175,34 @@
 }
 
 .sla-sheet .condition-grid {
-    gap: 4px;
+    gap: 10px;
     padding-top: 6px;
     justify-content: flex-start;
 }
 
 .sla-sheet .condition-toggle {
-    width: 34px;
-    height: 34px;
-    min-width: 34px;
-    min-height: 34px;
-    max-width: 34px;
-    max-height: 34px;
-    font-size: 1rem;
-    flex: 0 0 34px;
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    min-height: 32px;
+    max-width: 32px;
+    max-height: 32px;
+    font-size: 0.95rem;
+    flex: 0 0 32px;
+}
+
+.sla-sheet .sla-xp-button {
+    min-height: 22px;
+    width: 22px;
+    min-width: 22px;
+    padding: 0;
+    justify-content: center;
+    font-size: 0.7rem;
+
+    i {
+        font-size: 0.7rem;
+        line-height: 1;
+    }
 }
 
 .sla-sheet .sla-wound-summary {

--- a/src/scss/sheets/actor/_effects.scss
+++ b/src/scss/sheets/actor/_effects.scss
@@ -6,6 +6,46 @@
     display: flex;
     flex-direction: column;
     min-height: 0;
+
+    > .sla-header-bar.flexrow > span {
+        flex: 1;
+    }
+}
+
+/* Header add control — avoid Foundry's oversized default <button> chrome */
+.sla-sheet .sla-header-bar .sla-effect-create {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 22px;
+    height: 22px;
+    min-width: 22px;
+    min-height: 22px;
+    margin: 0 0 0 auto;
+    padding: 0;
+    border: 1px solid var(--sla-border);
+    border-radius: var(--sla-radius);
+    background: transparent;
+    color: var(--sla-text-muted, #888);
+    cursor: pointer;
+    line-height: 1;
+    font-size: 0.65rem;
+    box-shadow: none;
+
+    i {
+        font-size: 0.65rem;
+        line-height: 1;
+    }
+
+    &:hover,
+    &:focus-visible {
+        color: var(--sla-accent);
+        border-color: var(--sla-accent);
+        background: rgba(208, 94, 26, 0.08);
+        outline: none;
+        box-shadow: none;
+    }
 }
 
 .sla-sheet .sla-effects-toolbar {

--- a/src/scss/sheets/actor/_index.scss
+++ b/src/scss/sheets/actor/_index.scss
@@ -6,3 +6,4 @@
 @import 'drops';
 @import 'ux-enhancements';
 @import 'responsive';
+@import 'density';

--- a/src/scss/sheets/actor/_responsive.scss
+++ b/src/scss/sheets/actor/_responsive.scss
@@ -50,12 +50,19 @@
         padding: 4px;
     }
 
-    .sla-sheet .sheet-tabs.sla-sheet-tab-rail .sla-tab-rail-tooltip {
-        display: none;
+    .sla-sheet .sheet-tabs.sla-sheet-tab-rail {
+        width: 100%;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+        padding: 4px;
+        gap: 4px;
     }
 
-    .sla-sheet.sla-sheet-tabs-labeled .sheet-tabs.sla-sheet-tab-rail .sla-tab-rail-label {
-        display: block;
+    .sla-sheet .sheet-tabs.sla-sheet-tab-rail .item,
+    .sla-sheet .sheet-tabs.sla-sheet-tab-rail .sla-tab-rail-btn {
+        width: 36px;
+        height: 36px;
     }
 
     .sla-sheet .sla-combat-colhead,

--- a/src/scss/sheets/actor/_ux-enhancements.scss
+++ b/src/scss/sheets/actor/_ux-enhancements.scss
@@ -187,11 +187,8 @@
     margin-bottom: 6px;
 }
 
-/* Condition toggles — larger touch targets */
+/* Condition toggles — focus ring (size in _density.scss) */
 .sla-sheet .condition-toggle {
-    min-width: 44px;
-    min-height: 44px;
-
     &[role='button']:focus-visible {
         outline: 2px solid var(--sla-accent);
         outline-offset: 2px;
@@ -244,30 +241,12 @@
     border: 1px solid rgba(57, 255, 20, 0.35);
 }
 
-/* Tab rail — persistent label on focus, a11y */
+/* Tab rail — show tooltip on focus for keyboard users */
 .sla-sheet .sheet-tabs.sla-sheet-tab-rail .sla-tab-rail-btn {
-    min-width: 44px;
-    min-height: 44px;
-
-    &:focus-visible .sla-tab-rail-tooltip,
-    &[aria-selected='true'] .sla-tab-rail-tooltip {
+    &:focus-visible .sla-tab-rail-tooltip {
         opacity: 1;
         visibility: visible;
     }
-}
-
-.sla-sheet .sheet-tabs.sla-sheet-tab-rail .sla-tab-rail-label {
-    display: none;
-    font-size: 0.55rem;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    margin-top: 2px;
-    line-height: 1;
-    color: var(--sla-text-muted);
-}
-
-.sla-sheet.sla-sheet-tabs-labeled .sheet-tabs.sla-sheet-tab-rail .sla-tab-rail-label {
-    display: block;
 }
 
 .sla-sheet .sheet-body > .tab[role='tabpanel'] {

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "sla-industries",
     "title": "SLA Industries 2nd Edition",
     "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "compatibility": {
         "minimum": "14",
         "verified": "14.360"
@@ -46,7 +46,7 @@
     ],
     "url": "https://github.com/VacantFanatic/sla-foundry",
     "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.0/sla-industries.zip",
+    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.1/sla-industries.zip",
     "packs": [
         {
             "name": "skills",

--- a/templates/actor/actor-npc-sheet-v2.hbs
+++ b/templates/actor/actor-npc-sheet-v2.hbs
@@ -1,4 +1,4 @@
-<div class="{{cssClass}} sla-sheet threat-sheet standard-form sla-actor-layout sla-sheet-tabs-labeled" autocomplete="off">
+<div class="{{cssClass}} sla-sheet threat-sheet standard-form sla-actor-layout" autocomplete="off">
 
     {{!-- THREAT HEADER --}}
     <div class="threat-header">
@@ -140,7 +140,6 @@
                 <a class="item sla-tab-rail-btn {{tabs.combat.cssClass}}" href="#" id="sla-npc-tab-combat" role="tab" data-group="primary" data-tab="combat"
                     title="{{tabs.combat.label}}" aria-label="{{tabs.combat.label}}" aria-controls="sla-npc-tabpanel-combat">
                     <i class="fas {{tabs.combat.icon}}" aria-hidden="true"></i>
-                    <span class="sla-tab-rail-label">{{tabs.combat.label}}</span>
                     <span class="sla-tab-rail-tooltip">{{tabs.combat.label}}</span>
                 </a>
                 <a class="item sla-tab-rail-btn {{tabs.inventory.cssClass}}" href="#" data-group="primary" data-tab="inventory"

--- a/templates/actor/actor-sheet-v2.hbs
+++ b/templates/actor/actor-sheet-v2.hbs
@@ -1,4 +1,4 @@
-<div class="{{cssClass}} sla-sheet standard-form sla-actor-layout sla-sheet-tabs-labeled" autocomplete="off">
+<div class="{{cssClass}} sla-sheet standard-form sla-actor-layout" autocomplete="off">
 
     {{> "systems/sla-industries/templates/actor/parts/header-card.hbs"}}
 
@@ -50,38 +50,31 @@
         <nav class="sheet-tabs tabs sla-sheet-tab-rail" data-group="primary" role="tablist" aria-label="{{localize 'SLA.ActorSheet.TabNavLabel'}}">
             <a class="item sla-tab-rail-btn {{tabs.main.cssClass}}" href="#" id="sla-tab-main" role="tab" data-group="primary" data-tab="main" title="{{tabs.main.label}}" aria-label="{{tabs.main.label}}" aria-controls="sla-tabpanel-main">
                 <i class="fas {{tabs.main.icon}}" aria-hidden="true"></i>
-                <span class="sla-tab-rail-label">{{tabs.main.label}}</span>
                 <span class="sla-tab-rail-tooltip">{{tabs.main.label}}</span>
             </a>
             <a class="item sla-tab-rail-btn {{tabs.combat.cssClass}}" href="#" id="sla-tab-combat" role="tab" data-group="primary" data-tab="combat" title="{{tabs.combat.label}}" aria-label="{{tabs.combat.label}}" aria-controls="sla-tabpanel-combat">
                 <i class="fas {{tabs.combat.icon}}" aria-hidden="true"></i>
-                <span class="sla-tab-rail-label">{{tabs.combat.label}}</span>
                 <span class="sla-tab-rail-tooltip">{{tabs.combat.label}}</span>
             </a>
             <a class="item sla-tab-rail-btn {{tabs.inventory.cssClass}}" href="#" id="sla-tab-inventory" role="tab" data-group="primary" data-tab="inventory" title="{{tabs.inventory.label}}" aria-label="{{tabs.inventory.label}}" aria-controls="sla-tabpanel-inventory">
                 <i class="fas {{tabs.inventory.icon}}" aria-hidden="true"></i>
-                <span class="sla-tab-rail-label">{{tabs.inventory.label}}</span>
                 <span class="sla-tab-rail-tooltip">{{tabs.inventory.label}}</span>
             </a>
             <a class="item sla-tab-rail-btn {{tabs.effects.cssClass}}" href="#" id="sla-tab-effects" role="tab" data-group="primary" data-tab="effects" title="{{tabs.effects.label}}" aria-label="{{tabs.effects.label}}" aria-controls="sla-tabpanel-effects">
                 <i class="fas {{tabs.effects.icon}}" aria-hidden="true"></i>
-                <span class="sla-tab-rail-label">{{tabs.effects.label}}</span>
                 <span class="sla-tab-rail-tooltip">{{tabs.effects.label}}</span>
             </a>
             <a class="item sla-tab-rail-btn {{tabs.traits.cssClass}}" href="#" id="sla-tab-traits" role="tab" data-group="primary" data-tab="traits" title="{{tabs.traits.label}}" aria-label="{{tabs.traits.label}}" aria-controls="sla-tabpanel-traits">
                 <i class="fas {{tabs.traits.icon}}" aria-hidden="true"></i>
-                <span class="sla-tab-rail-label">{{tabs.traits.label}}</span>
                 <span class="sla-tab-rail-tooltip">{{tabs.traits.label}}</span>
             </a>
             <a class="item sla-tab-rail-btn {{tabs.notes.cssClass}}" href="#" id="sla-tab-notes" role="tab" data-group="primary" data-tab="notes" title="{{tabs.notes.label}}" aria-label="{{tabs.notes.label}}" aria-controls="sla-tabpanel-notes">
                 <i class="fas {{tabs.notes.icon}}" aria-hidden="true"></i>
-                <span class="sla-tab-rail-label">{{tabs.notes.label}}</span>
                 <span class="sla-tab-rail-tooltip">{{tabs.notes.label}}</span>
             </a>
             {{#if isEbonite}}
             <a class="item sla-tab-rail-btn {{tabs.ebb.cssClass}}" href="#" id="sla-tab-ebb" role="tab" data-group="primary" data-tab="ebb" title="{{tabs.ebb.label}}" aria-label="{{tabs.ebb.label}}" aria-controls="sla-tabpanel-ebb">
                 <i class="fas {{tabs.ebb.icon}}" aria-hidden="true"></i>
-                <span class="sla-tab-rail-label">{{tabs.ebb.label}}</span>
                 <span class="sla-tab-rail-tooltip">{{tabs.ebb.label}}</span>
             </a>
             {{/if}}

--- a/templates/actor/parts/secondary.hbs
+++ b/templates/actor/parts/secondary.hbs
@@ -36,7 +36,7 @@
         <div class="compact-row">
             <label title="{{localize 'SLA.ActorSheet.HitPoints'}}">{{localize "SLA.ActorSheet.HitPoints"}}</label>
             <div class="flexrow sla-hp-inputs">
-                <input type="number" name="system.hp.value" value="{{system.hp.value}}" class="sla-input-mini"/>
+                <input type="number" name="system.hp.value" value="{{system.hp.value}}" min="0" max="{{system.hp.max}}" class="sla-input-mini"/>
                 <span class="sla-hp-sep">/</span>
                 <input type="number" name="system.hp.max" value="{{system.hp.max}}" class="sla-input-mini" readonly />
             </div>
@@ -63,7 +63,6 @@
                 <input type="number" name="system.xp.value" value="{{system.xp.value}}" class="sla-input-mini" readonly />
                 <button type="button" class="xp-button sla-xp-button" title="{{localize 'SLA.ActorSheet.ManageXP'}}" aria-label="{{localize 'SLA.ActorSheet.ManageXP'}}">
                     <i class="fas fa-coins" aria-hidden="true"></i>
-                    <span>{{localize "SLA.ActorSheet.ManageXP"}}</span>
                 </button>
             </div>
         </div>

--- a/tests/e2e/capture-actor-sheet-screenshots.spec.js
+++ b/tests/e2e/capture-actor-sheet-screenshots.spec.js
@@ -1,0 +1,122 @@
+/**
+ * Capture actor sheet screenshots for UX review.
+ * Output: test-results/sheet-screenshots/*.png
+ */
+const fs = require('node:fs');
+const path = require('node:path');
+const { test } = require('@playwright/test');
+const {
+    joinGame,
+    waitForSLASystem,
+    dismissFoundryNotifications,
+    createTestActor,
+    openActorSheet,
+    clickActorSheetTab,
+    deleteTestActors,
+    closeApplicationWindows
+} = require('./fixtures');
+
+const OUT_DIR = path.join(process.cwd(), 'test-results', 'sheet-screenshots');
+const ARTIFACT_DIR = '/opt/cursor/artifacts/screenshots';
+
+function outputDirs() {
+    const dirs = [OUT_DIR];
+    try {
+        fs.mkdirSync(path.dirname(ARTIFACT_DIR), { recursive: true });
+        dirs.push(ARTIFACT_DIR);
+    } catch {
+        /* optional path */
+    }
+    return dirs;
+}
+
+async function saveShot(locator, name) {
+    for (const dir of outputDirs()) {
+        fs.mkdirSync(dir, { recursive: true });
+        await locator.screenshot({ path: path.join(dir, `${name}.png`) });
+    }
+}
+
+test.describe.configure({ timeout: 90_000 });
+
+test.describe('Actor sheet screenshot capture', () => {
+    test.beforeEach(async ({ page }) => {
+        test.skip(!process.env.FOUNDRY_USER, 'Set FOUNDRY_USER');
+        await joinGame(page);
+        await waitForSLASystem(page);
+        const gm = await page.evaluate(() => game.user?.isGM === true);
+        test.skip(!gm, 'Requires GM');
+        await page.evaluate(() => {
+            if (globalThis.game?.paused) globalThis.game.togglePause();
+        });
+        await dismissFoundryNotifications(page);
+    });
+
+    test.afterEach(async ({ page }) => {
+        await deleteTestActors(page);
+        await page
+            .evaluate(async () => {
+                for (const actor of game.actors.filter((a) => a.name?.startsWith('Screenshot '))) {
+                    await actor.delete();
+                }
+            })
+            .catch(() => {});
+        await closeApplicationWindows(page);
+    });
+
+    test('capture operative sheet regions', async ({ page }) => {
+        const actorId = await page.evaluate(async () => {
+            const stamp = Date.now();
+            const [actor] = await Actor.createDocuments([
+                {
+                    name: `Screenshot Operative ${stamp}`,
+                    type: 'character',
+                    system: {
+                        stats: { str: { value: 4 }, dex: { value: 3 }, init: { value: 22 } },
+                        hp: { value: 22, max: 30 },
+                        finance: { credits: 1820, unis: 0, debt: 0 },
+                        wounds: { head: false, torso: false, lArm: true, rArm: false, lLeg: false, rLeg: false }
+                    }
+                }
+            ]);
+            return actor.id;
+        });
+
+        const sheet = await openActorSheet(page, actorId);
+
+        await saveShot(sheet, '01-operative-sheet');
+        await saveShot(sheet.locator('.sheet-header'), '02-operative-header');
+        await saveShot(sheet.locator('.stats-strip-container'), '03-operative-stats-strip');
+        await saveShot(sheet.locator('nav.sla-sheet-tab-rail'), '04-operative-tab-rail');
+
+        await clickActorSheetTab(sheet, 'combat');
+        await saveShot(sheet.locator('.tab[data-tab="combat"] .sla-panel').first(), '05-operative-wounds');
+        if ((await sheet.locator('.sla-combat-loadout').count()) > 0) {
+            await saveShot(sheet.locator('.sla-combat-loadout'), '06-operative-combat-loadout');
+        }
+
+        await clickActorSheetTab(sheet, 'main');
+        if ((await sheet.locator('.right-col').count()) > 0) {
+            await saveShot(sheet.locator('.right-col'), '07-operative-vitals');
+        }
+    });
+
+    test('capture NPC threat sheet', async ({ page }) => {
+        const npcId = await page.evaluate(async () => {
+            const stamp = Date.now();
+            const [actor] = await Actor.createDocuments([
+                { name: `Screenshot NPC ${stamp}`, type: 'npc', system: { hp: { value: 10, max: 10 } } }
+            ]);
+            return actor.id;
+        });
+
+        await page.evaluate(async (id) => {
+            const actor = game.actors.get(id);
+            await actor.sheet.render(true);
+        }, npcId);
+
+        const sheet = page.locator('form.application.sla-industries.actor').last();
+        await sheet.waitFor({ state: 'visible' });
+        await saveShot(sheet, '08-npc-threat-sheet');
+    });
+});

--- a/tests/e2e/capture-actor-sheet-screenshots.spec.js
+++ b/tests/e2e/capture-actor-sheet-screenshots.spec.js
@@ -107,6 +107,13 @@ test.describe('Actor sheet screenshot capture', () => {
         if ((await vitalsCol.count()) > 0) {
             await saveShot(vitalsCol, '07-operative-vitals-xp');
         }
+
+        await clickActorSheetTab(sheet, 'effects');
+        const effectsHeader = sheet.locator('.sla-effects-panel > .sla-header-bar');
+        if ((await effectsHeader.count()) > 0) {
+            await saveShot(effectsHeader, '08-operative-effects-header');
+        }
+        await saveShot(sheet.locator('.sla-effects-panel'), '08-operative-effects-panel');
     });
 
     test('capture NPC threat sheet — all tabs', async ({ page }) => {

--- a/tests/e2e/capture-actor-sheet-screenshots.spec.js
+++ b/tests/e2e/capture-actor-sheet-screenshots.spec.js
@@ -37,7 +37,7 @@ async function saveShot(locator, name) {
     }
 }
 
-test.describe.configure({ timeout: 90_000 });
+test.describe.configure({ timeout: 180_000 });
 
 test.describe('Actor sheet screenshot capture', () => {
     test.beforeEach(async ({ page }) => {
@@ -64,7 +64,7 @@ test.describe('Actor sheet screenshot capture', () => {
         await closeApplicationWindows(page);
     });
 
-    test('capture operative sheet regions', async ({ page }) => {
+    test('capture operative sheet — all tabs and density regions', async ({ page }) => {
         const actorId = await page.evaluate(async () => {
             const stamp = Date.now();
             const [actor] = await Actor.createDocuments([
@@ -74,6 +74,7 @@ test.describe('Actor sheet screenshot capture', () => {
                     system: {
                         stats: { str: { value: 4 }, dex: { value: 3 }, init: { value: 22 } },
                         hp: { value: 22, max: 30 },
+                        xp: { value: 120 },
                         finance: { credits: 1820, unis: 0, debt: 0 },
                         wounds: { head: false, torso: false, lArm: true, rArm: false, lLeg: false, rLeg: false }
                     }
@@ -83,25 +84,32 @@ test.describe('Actor sheet screenshot capture', () => {
         });
 
         const sheet = await openActorSheet(page, actorId);
+        const operativeTabs = ['main', 'combat', 'inventory', 'effects', 'traits', 'notes'];
 
-        await saveShot(sheet, '01-operative-sheet');
         await saveShot(sheet.locator('.sheet-header'), '02-operative-header');
         await saveShot(sheet.locator('.stats-strip-container'), '03-operative-stats-strip');
         await saveShot(sheet.locator('nav.sla-sheet-tab-rail'), '04-operative-tab-rail');
 
+        for (const tabId of operativeTabs) {
+            await clickActorSheetTab(sheet, tabId);
+            await sheet.locator(`nav.sheet-tabs a[data-tab="${tabId}"].active`).waitFor({ state: 'attached' });
+            await saveShot(sheet, `tab-${tabId}-full`);
+        }
+
         await clickActorSheetTab(sheet, 'combat');
-        await saveShot(sheet.locator('.tab[data-tab="combat"] .sla-panel').first(), '05-operative-wounds');
-        if ((await sheet.locator('.sla-combat-loadout').count()) > 0) {
-            await saveShot(sheet.locator('.sla-combat-loadout'), '06-operative-combat-loadout');
+        const woundPanel = sheet.locator('.sla-wound-panel');
+        if ((await woundPanel.count()) > 0) {
+            await saveShot(woundPanel, '05-operative-wounds-conditions');
         }
 
         await clickActorSheetTab(sheet, 'main');
-        if ((await sheet.locator('.right-col').count()) > 0) {
-            await saveShot(sheet.locator('.right-col'), '07-operative-vitals');
+        const vitalsCol = sheet.locator('.right-col');
+        if ((await vitalsCol.count()) > 0) {
+            await saveShot(vitalsCol, '07-operative-vitals-xp');
         }
     });
 
-    test('capture NPC threat sheet', async ({ page }) => {
+    test('capture NPC threat sheet — all tabs', async ({ page }) => {
         const npcId = await page.evaluate(async () => {
             const stamp = Date.now();
             const [actor] = await Actor.createDocuments([
@@ -110,13 +118,13 @@ test.describe('Actor sheet screenshot capture', () => {
             return actor.id;
         });
 
-        await page.evaluate(async (id) => {
-            const actor = game.actors.get(id);
-            await actor.sheet.render(true);
-        }, npcId);
+        const sheet = await openActorSheet(page, npcId);
+        const npcTabs = ['combat', 'inventory', 'effects', 'skills', 'notes'];
 
-        const sheet = page.locator('form.application.sla-industries.actor').last();
-        await sheet.waitFor({ state: 'visible' });
-        await saveShot(sheet, '08-npc-threat-sheet');
+        for (const tabId of npcTabs) {
+            await clickActorSheetTab(sheet, tabId);
+            await sheet.locator(`nav.sheet-tabs a[data-tab="${tabId}"].active`).waitFor({ state: 'attached' });
+            await saveShot(sheet, `npc-tab-${tabId}-full`);
+        }
     });
 });

--- a/tests/unit/sheet-ux-pure.test.mjs
+++ b/tests/unit/sheet-ux-pure.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
+    clampHpValue,
     countWounds,
     hpBarState,
     isEncumbranceOverloaded,
@@ -20,6 +21,14 @@ describe('sheet-ux-pure', () => {
         assert.equal(statPlayColorClass(5, 3), 'sla-stat-buffed');
         assert.equal(statPlayColorClass(2, 4), 'sla-stat-debuffed');
         assert.equal(statPlayColorClass(4, 4), 'sla-stat-neutral');
+    });
+
+    it('clampHpValue floors at zero and ceilings at max', () => {
+        assert.equal(clampHpValue(5, 10), 5);
+        assert.equal(clampHpValue(15, 10), 10);
+        assert.equal(clampHpValue(-3, 10), 0);
+        assert.equal(clampHpValue(8, 0), 0);
+        assert.equal(clampHpValue('12', '9'), 9);
     });
 
     it('hpBarState returns percent and tone thresholds', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up density tweaks from UX screenshots:

- **Manage XP** — icon-only 22×22 button (tooltip + `aria-label` retained)
- **Wounds** — smaller labels (0.62rem) and 12px checkboxes
- **Conditions** — increased gap between toggles (10px) while keeping compact 32px icons
- **HP validation** — `clampHpValue` ensures HP stays within `[0, max]` on sheet edit, `_preUpdate`, and when derived max drops (e.g. STR decrease)

## Test plan

- [x] `npm run test:unit` (120 pass, includes `clampHpValue` tests)
- [x] `npm run build`
- [x] E2E regression when Foundry available
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05f18344-61b8-4563-958b-a68e7b3b2b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05f18344-61b8-4563-958b-a68e7b3b2b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

