### PR TITLE
Add npm version lifecycle hook and changelog extraction for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,21 @@ jobs:
             - name: Run unit tests
               run: npm run test:unit
 
+            - name: Extract changelog for this release
+              id: changelog
+              run: |
+                  VERSION="${{ steps.get-version.outputs.version }}"
+                  BODY=$(python3 -c "
+                  import re, sys
+                  text = open('CHANGELOG.md').read()
+                  version = sys.argv[1]
+                  m = re.search(r'\n## \[' + re.escape(version) + r'\][^\n]*\n(.*?)(?=\n## \[|\Z)', text, re.DOTALL)
+                  print(m.group(1).strip() if m else '')
+                  " "$VERSION")
+                  echo "body<<EOF" >> "$GITHUB_OUTPUT"
+                  echo "$BODY" >> "$GITHUB_OUTPUT"
+                  echo "EOF" >> "$GITHUB_OUTPUT"
+
             - name: Build and package release zip
               run: npm run package
 
@@ -67,6 +82,10 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   artifacts: './system.json,./sla-industries.zip'
                   tag: ${{ steps.get-version.outputs.version }}
+                  body: |
+                      ${{ steps.changelog.outputs.body }}
+
+                      [Full changelog](https://github.com/VacantFanatic/sla-foundry/blob/master/CHANGELOG.md)
 
             - name: Create Latest release
               id: create_latest_release

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "test:env": "bash scripts/test-environment.sh",
         "foundry:start": "bash scripts/cloud-foundry.sh start",
         "foundry:status": "bash scripts/cloud-foundry.sh status",
+        "version": "./scripts/version.mjs && git add system.json CHANGELOG.md",
         "test": "npm run test:unit && npm run test:e2e"
     },
     "browserslist": [

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import packageJson from "../package.json" with { type: "json" };
+
+const REPO = "https://github.com/VacantFanatic/sla-foundry";
+const version = packageJson.version;
+
+// Update system.json version and download URL
+const manifest = JSON.parse(fs.readFileSync("system.json", "utf8"));
+manifest.version = version;
+manifest.download = `${REPO}/releases/download/${version}/sla-industries.zip`;
+fs.writeFileSync("system.json", JSON.stringify(manifest, null, 4) + "\n");
+
+// Promote [Unreleased] to the new version in CHANGELOG.md
+const changelogPath = "CHANGELOG.md";
+const changelog = fs.readFileSync(changelogPath, "utf8");
+
+const UNRELEASED_HEADER = "## [Unreleased]";
+const headerIndex = changelog.indexOf(UNRELEASED_HEADER);
+if (headerIndex === -1) {
+    console.error("ERROR: No [Unreleased] section found in CHANGELOG.md");
+    process.exit(1);
+}
+
+const afterHeader = changelog.slice(headerIndex + UNRELEASED_HEADER.length);
+const nextSectionMatch = afterHeader.match(/\n## \[/);
+const unreleasedContent = (
+    nextSectionMatch ? afterHeader.slice(0, nextSectionMatch.index) : afterHeader
+).trim();
+
+if (!unreleasedContent) {
+    console.error(
+        "ERROR: [Unreleased] section in CHANGELOG.md is empty.\n" +
+            "Add entries under ## [Unreleased] before running npm version."
+    );
+    process.exit(1);
+}
+
+const today = new Date().toISOString().split("T")[0];
+
+// Insert a new versioned header after [Unreleased]
+let newChangelog = changelog.replace(
+    UNRELEASED_HEADER + "\n",
+    `${UNRELEASED_HEADER}\n\n## [${version}] - ${today}\n`
+);
+
+// Update the [Unreleased] reference link and insert the new version link beneath it
+const unreleasedLinkRegex = /^\[Unreleased\]:.+$/m;
+const newUnreleasedLink = `[Unreleased]: ${REPO}/compare/${version}...HEAD`;
+const newVersionLink = `[${version}]: ${REPO}/releases/tag/${version}`;
+
+if (unreleasedLinkRegex.test(newChangelog)) {
+    newChangelog = newChangelog.replace(
+        unreleasedLinkRegex,
+        `${newUnreleasedLink}\n${newVersionLink}`
+    );
+} else {
+    newChangelog = newChangelog.trimEnd() + `\n\n${newUnreleasedLink}\n${newVersionLink}\n`;
+}
+
+fs.writeFileSync(changelogPath, newChangelog);


### PR DESCRIPTION
- scripts/version.mjs: npm `version` hook that syncs system.json version
  and download URL from package.json, promotes ## [Unreleased] to a dated
  versioned entry in CHANGELOG.md, and updates the reference links at the
  bottom; exits 1 if the unreleased section is missing or empty
- package.json: wire `version` script so `npm version patch/minor/major`
  triggers the hook and stages system.json + CHANGELOG.md for npm's
  auto-commit
- release.yml: extract the versioned changelog section and include it as
  the release body, resolving the existing TODO

https://claude.ai/code/session_01XfsekSTu3z2FupYtGneJmT