### PR TITLE
Add configurable Training Packages compendium setting to prevent overwrite

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -47,6 +47,7 @@
     "SLA.ActorSheet.DropSpecies": "Drop species here",
     "SLA.ActorSheet.DropPackage": "Drop training package here",
     "SLA.ActorSheet.OpenCompendium": "Open compendium",
+    "SLA.Notification.PackagesCompendiumNotConfigured": "No Training Packages compendium is configured. Create a world-level compendium containing your package items, then set its ID in System Settings → Training Packages Compendium.",
     "SLA.ActorSheet.RemoveChip": "Remove",
     "SLA.ActorSheet.LAD": "LAD",
     "SLA.ActorSheet.LADHint": "Light Amplification Device",

--- a/module/sheets/actor/sheet-actions.mjs
+++ b/module/sheets/actor/sheet-actions.mjs
@@ -70,10 +70,17 @@ export async function handleSheetClick(sheet, event) {
     const comp = t.closest('.open-compendium');
     if (comp) {
         event.preventDefault();
-        const compendiumId = comp.dataset.compendium;
+        let compendiumId = comp.dataset.compendium;
+        if (compendiumId === 'sla-industries.packages') {
+            const configured = (game.settings.get('sla-industries', 'packagesCompendiumId') ?? '').trim();
+            if (configured) compendiumId = configured;
+        }
         const pack = game.packs.get(compendiumId);
-        if (pack) pack.render(true);
-        else ui.notifications.warn(`Compendium '${compendiumId}' not found.`);
+        if (pack) {
+            pack.render(true);
+        } else {
+            ui.notifications.warn(game.i18n.localize('SLA.Notification.PackagesCompendiumNotConfigured'));
+        }
         return;
     }
 

--- a/module/sla-industries.mjs
+++ b/module/sla-industries.mjs
@@ -257,6 +257,15 @@ Hooks.once('init', async function () {
         default: true
     });
 
+    game.settings.register('sla-industries', 'packagesCompendiumId', {
+        name: 'Training Packages Compendium',
+        hint: 'The ID of the compendium pack opened when clicking the Training Package field on actor sheets. System-owned packs are replaced on every update, so create a world-level compendium (Compendium tab → Create Compendium, type Item) containing your package items and paste its ID here — for example "world.packages". World compendiums are stored in your world folder and are never overwritten by system updates.',
+        scope: 'world',
+        config: true,
+        type: String,
+        default: ''
+    });
+
     CONFIG.statusEffects = SLA.statusEffects;
     CONFIG.Actor.trackableAttributes = SLA.trackableAttributes;
 


### PR DESCRIPTION
System-owned compendium packs are replaced on every system update, so
any packages a GM adds to sla-industries.packages would be wiped.

Introduces a world-scoped setting (packagesCompendiumId) where a GM can
point the Package field click-handler at a world-level compendium instead.
World compendiums live in the world folder and are never touched by system
updates. If no compendium is configured the handler now shows an actionable
notification rather than a generic "not found" warning.

https://claude.ai/code/session_014UsdTmjGpyUXynmjy5Xun3