### PR TITLE
Bump version to 2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.8.2] - 2026-06-10
+
+### Added
+
+- **Configurable Training Packages compendium:** New world setting _Training Packages Compendium_ lets GMs point the Package field click-handler at a world-level compendium. World compendiums are stored in the world folder and are never overwritten by system updates. If no compendium is configured, clicking the Package field now shows an actionable notification with setup instructions instead of a generic "not found" warning.
+
 ## [2.8.1] - 2026-06-08
 
 ### Changed
@@ -912,7 +918,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Damage application targeting both selected token and target.
 - Degree of success display regression on weapon attacks.
 
-[Unreleased]: https://github.com/VacantFanatic/sla-foundry/compare/2.5.4...HEAD
+[Unreleased]: https://github.com/VacantFanatic/sla-foundry/compare/2.8.2...HEAD
+[2.8.2]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.8.2
 [2.5.4]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.4
 [2.5.3]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.3
 [2.5.2]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sla-industries",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "description": "CSS compiler for the SLA Industries system",
     "scripts": {
         "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "sla-industries",
     "title": "SLA Industries 2nd Edition",
     "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "compatibility": {
         "minimum": "14",
         "verified": "14.360"
@@ -46,7 +46,7 @@
     ],
     "url": "https://github.com/VacantFanatic/sla-foundry",
     "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.1/sla-industries.zip",
+    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.2/sla-industries.zip",
     "packs": [
         {
             "name": "skills",


### PR DESCRIPTION
Version bump to 2.8.2 ahead of the `pre-2.8.2-rc1` pre-release.

### Changes since 2.8.1
- Configurable Training Packages compendium setting (prevents GM content being overwritten by system updates)

https://claude.ai/code/session_014UsdTmjGpyUXynmjy5Xun3

---
_Generated by [Claude Code](https://claude.ai/code/session_014UsdTmjGpyUXynmjy5Xun3)_