### PR TITLE
Add workflow_dispatch to pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -4,6 +4,12 @@ permissions:
     contents: write
 
 on:
+    workflow_dispatch:
+        inputs:
+            tag_name:
+                description: 'Pre-release tag to create and publish (e.g. pre-2.8.2-rc1)'
+                required: true
+                type: string
     push:
         tags:
             - 'pre-[0-9]+.[0-9]+.[0-9]+'
@@ -22,9 +28,18 @@ jobs:
                   node-version: '22'
                   cache: npm
 
+            - name: Resolve tag name
+              id: resolve-tag
+              run: |
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                    echo "tag=${{ inputs.tag_name }}" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Resolve version from tag
               id: get-version
-              run: node scripts/resolve-prerelease-tag.mjs "${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+              run: node scripts/resolve-prerelease-tag.mjs "${{ steps.resolve-tag.outputs.tag }}" >> "$GITHUB_OUTPUT"
 
             - name: Install dependencies
               run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.8.2] - 2026-06-10
+
+### Added
+
+- **Configurable Training Packages compendium:** New world setting _Training Packages Compendium_ lets GMs point the Package field click-handler at a world-level compendium. World compendiums are stored in the world folder and are never overwritten by system updates. If no compendium is configured, clicking the Package field now shows an actionable notification with setup instructions instead of a generic "not found" warning.
+
 ## [2.8.1] - 2026-06-08
 
 ### Changed
@@ -912,7 +918,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Damage application targeting both selected token and target.
 - Degree of success display regression on weapon attacks.
 
-[Unreleased]: https://github.com/VacantFanatic/sla-foundry/compare/2.5.4...HEAD
+[Unreleased]: https://github.com/VacantFanatic/sla-foundry/compare/2.8.2...HEAD
+[2.8.2]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.8.2
 [2.5.4]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.4
 [2.5.3]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.3
 [2.5.2]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sla-industries",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "description": "CSS compiler for the SLA Industries system",
     "scripts": {
         "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "sla-industries",
     "title": "SLA Industries 2nd Edition",
     "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "compatibility": {
         "minimum": "14",
         "verified": "14.360"
@@ -46,7 +46,7 @@
     ],
     "url": "https://github.com/VacantFanatic/sla-foundry",
     "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.1/sla-industries.zip",
+    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.2/sla-industries.zip",
     "packs": [
         {
             "name": "skills",


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger so pre-releases can be fired via the GitHub API (Actions tab or API call) without needing to push a git tag locally.

The tag name is accepted as an input and behaves identically to the existing tag-push path.

https://claude.ai/code/session_014UsdTmjGpyUXynmjy5Xun3

---
_Generated by [Claude Code](https://claude.ai/code/session_014UsdTmjGpyUXynmjy5Xun3)_