### PR TITLE
Refactor wound system to use interactive diagram instead of checkboxes

### DIFF
--- a/module/sheets/actor/sheet-actions.mjs
+++ b/module/sheets/actor/sheet-actions.mjs
@@ -44,6 +44,19 @@ export async function handleSheetClick(sheet, event) {
     const t = event.target;
     if (!(t instanceof Element)) return;
 
+    const woundSlot = t.closest('.sla-wound-diagram__slot[data-wound]');
+    if (woundSlot) {
+        event.preventDefault();
+        const key = woundSlot.dataset.wound;
+        const current = sheet.actor.system.wounds?.[key] ?? false;
+        try {
+            await sheet.actor.update({ [`system.wounds.${key}`]: !current });
+        } catch (error) {
+            console.error('SLA Industries | Error updating wound:', error);
+        }
+        return;
+    }
+
     const cond = t.closest('.condition-toggle');
     if (cond) {
         event.preventDefault();
@@ -294,23 +307,5 @@ export async function handleSheetChange(sheet, event) {
             hpInput.value = String(clamped);
         }
         return;
-    }
-
-    const woundCb = el.closest('.wound-checkbox');
-    if (woundCb) {
-        const field = woundCb.name;
-        const isChecked = woundCb.checked;
-        if (sheet.actor.type === 'npc') {
-            const systemPath = field.replace('system.', '');
-            const currentValue = foundry.utils.getProperty(sheet.actor.system, systemPath);
-            if (currentValue === isChecked) return;
-        }
-        const updateData = { [field]: isChecked };
-        try {
-            await sheet.actor.update(updateData);
-        } catch (error) {
-            console.error('SLA Industries | Error updating actor:', error);
-            woundCb.checked = !isChecked;
-        }
     }
 }

--- a/src/scss/sheets/actor/_density.scss
+++ b/src/scss/sheets/actor/_density.scss
@@ -133,44 +133,14 @@
 }
 
 /* --- Wounds & conditions ------------------------------------------------- */
-.sla-sheet .wound-list {
-    gap: 4px;
-    margin-bottom: 6px;
-}
-
-.sla-sheet .wound-entry {
-    padding: 1px 4px;
-    min-height: 0;
-    gap: 4px;
-
-    label {
-        font-size: 0.62rem;
-        font-weight: 600;
-        line-height: 1.1;
-    }
-
-    .wound-checkbox {
-        width: 12px !important;
-        height: 12px !important;
-        min-width: 12px !important;
-        min-height: 12px !important;
-        margin: 0;
-    }
-}
-
-.sla-sheet .sla-wound-panel {
-    gap: 8px;
-}
-
 .sla-sheet .sla-wound-diagram {
-    min-width: 96px;
     padding: 4px;
     gap: 3px;
 }
 
 .sla-sheet .sla-wound-diagram__slot {
-    width: 28px;
-    height: 22px;
+    width: 36px;
+    height: 28px;
     font-size: 0.58rem;
 }
 

--- a/src/scss/sheets/actor/_responsive.scss
+++ b/src/scss/sheets/actor/_responsive.scss
@@ -69,10 +69,6 @@
     .sla-sheet .sla-combat-row {
         grid-template-columns: 1fr 4rem 5rem 100px !important;
     }
-
-    .sla-sheet .sla-wound-panel {
-        grid-template-columns: 1fr;
-    }
 }
 
 @media (max-width: 520px) {

--- a/src/scss/sheets/actor/_ux-enhancements.scss
+++ b/src/scss/sheets/actor/_ux-enhancements.scss
@@ -114,13 +114,6 @@
 }
 
 /* Wound diagram */
-.sla-sheet .sla-wound-panel {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 10px;
-    align-items: start;
-}
-
 .sla-sheet .sla-wound-diagram {
     display: grid;
     grid-template-areas:
@@ -130,16 +123,14 @@
     gap: 4px;
     justify-items: center;
     align-items: center;
-    min-width: 120px;
+    justify-content: center;
     padding: 6px;
-    border: 1px solid var(--sla-border);
-    border-radius: var(--sla-radius);
-    background: rgba(0, 0, 0, 0.25);
+    margin-bottom: 4px;
 }
 
 .sla-sheet .sla-wound-diagram__slot {
-    width: 36px;
-    height: 28px;
+    width: 44px;
+    height: 34px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -148,11 +139,34 @@
     color: #888;
     border: 1px dashed #444;
     border-radius: 3px;
+    cursor: pointer;
+    user-select: none;
+    transition:
+        border-color 0.15s,
+        background 0.15s,
+        color 0.15s;
+
+    &:hover {
+        border-color: #777;
+        color: #bbb;
+        background: rgba(255, 255, 255, 0.05);
+    }
+
+    &:focus-visible {
+        outline: 2px solid var(--sla-accent);
+        outline-offset: 2px;
+    }
 
     &.is-wounded {
         border-color: #ff5555;
+        border-style: solid;
         background: rgba(255, 85, 85, 0.15);
         color: #ffaaaa;
+
+        &:hover {
+            border-color: #ff8888;
+            background: rgba(255, 85, 85, 0.25);
+        }
     }
 
     &[data-area='head'] {

--- a/templates/actor/parts/wounds.hbs
+++ b/templates/actor/parts/wounds.hbs
@@ -7,42 +7,13 @@
         <div class="sla-wound-summary">{{woundCountLabel}}</div>
         {{/if}}
 
-        <div class="sla-wound-panel">
-            <div class="wound-list">
-                <div class="wound-entry">
-                    <label for="wound-head">{{localize "SLA.ActorSheet.WoundHead"}}</label>
-                    <input type="checkbox" class="wound-checkbox" id="wound-head" name="system.wounds.head" {{checked system.wounds.head}}/>
-                </div>
-                <div class="wound-entry">
-                    <label for="wound-torso">{{localize "SLA.ActorSheet.WoundTorso"}}</label>
-                    <input type="checkbox" class="wound-checkbox" id="wound-torso" name="system.wounds.torso" {{checked system.wounds.torso}}/>
-                </div>
-                <div class="wound-entry">
-                    <label for="wound-larm">{{localize "SLA.ActorSheet.WoundLArm"}}</label>
-                    <input type="checkbox" class="wound-checkbox" id="wound-larm" name="system.wounds.lArm" {{checked system.wounds.lArm}}/>
-                </div>
-                <div class="wound-entry">
-                    <label for="wound-rarm">{{localize "SLA.ActorSheet.WoundRArm"}}</label>
-                    <input type="checkbox" class="wound-checkbox" id="wound-rarm" name="system.wounds.rArm" {{checked system.wounds.rArm}}/>
-                </div>
-                <div class="wound-entry">
-                    <label for="wound-lleg">{{localize "SLA.ActorSheet.WoundLLeg"}}</label>
-                    <input type="checkbox" class="wound-checkbox" id="wound-lleg" name="system.wounds.lLeg" {{checked system.wounds.lLeg}}/>
-                </div>
-                <div class="wound-entry">
-                    <label for="wound-rleg">{{localize "SLA.ActorSheet.WoundRLeg"}}</label>
-                    <input type="checkbox" class="wound-checkbox" id="wound-rleg" name="system.wounds.rLeg" {{checked system.wounds.rLeg}}/>
-                </div>
-            </div>
-
-            <div class="sla-wound-diagram" aria-hidden="true">
-                <div class="sla-wound-diagram__slot {{#if system.wounds.head}}is-wounded{{/if}}" data-area="head">Hd</div>
-                <div class="sla-wound-diagram__slot {{#if system.wounds.lArm}}is-wounded{{/if}}" data-area="larm">LA</div>
-                <div class="sla-wound-diagram__slot {{#if system.wounds.torso}}is-wounded{{/if}}" data-area="torso">To</div>
-                <div class="sla-wound-diagram__slot {{#if system.wounds.rArm}}is-wounded{{/if}}" data-area="rarm">RA</div>
-                <div class="sla-wound-diagram__slot {{#if system.wounds.lLeg}}is-wounded{{/if}}" data-area="lleg">LL</div>
-                <div class="sla-wound-diagram__slot {{#if system.wounds.rLeg}}is-wounded{{/if}}" data-area="rleg">RL</div>
-            </div>
+        <div class="sla-wound-diagram">
+            <div class="sla-wound-diagram__slot {{#if system.wounds.head}}is-wounded{{/if}}" data-area="head" data-wound="head" role="button" tabindex="0" aria-pressed="{{system.wounds.head}}" aria-label="{{localize 'SLA.ActorSheet.WoundHead'}}" title="{{localize 'SLA.ActorSheet.WoundHead'}}">Hd</div>
+            <div class="sla-wound-diagram__slot {{#if system.wounds.lArm}}is-wounded{{/if}}" data-area="larm" data-wound="lArm" role="button" tabindex="0" aria-pressed="{{system.wounds.lArm}}" aria-label="{{localize 'SLA.ActorSheet.WoundLArm'}}" title="{{localize 'SLA.ActorSheet.WoundLArm'}}">LA</div>
+            <div class="sla-wound-diagram__slot {{#if system.wounds.torso}}is-wounded{{/if}}" data-area="torso" data-wound="torso" role="button" tabindex="0" aria-pressed="{{system.wounds.torso}}" aria-label="{{localize 'SLA.ActorSheet.WoundTorso'}}" title="{{localize 'SLA.ActorSheet.WoundTorso'}}">To</div>
+            <div class="sla-wound-diagram__slot {{#if system.wounds.rArm}}is-wounded{{/if}}" data-area="rarm" data-wound="rArm" role="button" tabindex="0" aria-pressed="{{system.wounds.rArm}}" aria-label="{{localize 'SLA.ActorSheet.WoundRArm'}}" title="{{localize 'SLA.ActorSheet.WoundRArm'}}">RA</div>
+            <div class="sla-wound-diagram__slot {{#if system.wounds.lLeg}}is-wounded{{/if}}" data-area="lleg" data-wound="lLeg" role="button" tabindex="0" aria-pressed="{{system.wounds.lLeg}}" aria-label="{{localize 'SLA.ActorSheet.WoundLLeg'}}" title="{{localize 'SLA.ActorSheet.WoundLLeg'}}">LL</div>
+            <div class="sla-wound-diagram__slot {{#if system.wounds.rLeg}}is-wounded{{/if}}" data-area="rleg" data-wound="rLeg" role="button" tabindex="0" aria-pressed="{{system.wounds.rLeg}}" aria-label="{{localize 'SLA.ActorSheet.WoundRLeg'}}" title="{{localize 'SLA.ActorSheet.WoundRLeg'}}">RL</div>
         </div>
         {{/if}}
 


### PR DESCRIPTION
## Summary
Replaced the wound management UI from a separate checkbox list + diagram layout with a single interactive wound diagram where each body part slot functions as a clickable button. This simplifies the interface and improves accessibility.

## Key Changes

- **Template refactor** (`templates/actor/parts/wounds.hbs`):
  - Removed the separate `.wound-list` with individual checkbox inputs
  - Removed the `.sla-wound-panel` grid wrapper
  - Converted diagram slots to interactive buttons with semantic HTML attributes (`role="button"`, `tabindex="0"`, `aria-pressed`, `aria-label`)
  - Added `data-wound` attributes to map slots to wound properties

- **Event handling** (`module/sheets/actor/sheet-actions.mjs`):
  - Moved wound toggle logic from `handleSheetChange` (checkbox change handler) to `handleSheetClick`
  - New click handler targets `.sla-wound-diagram__slot[data-wound]` elements
  - Directly updates actor wounds via `actor.update()` on click

- **Styling** (`src/scss/sheets/actor/_ux-enhancements.scss`):
  - Removed `.sla-wound-panel` grid styles
  - Enhanced `.sla-wound-diagram__slot` with interactive states:
    - Added `cursor: pointer`, `user-select: none`, and smooth transitions
    - Added `:hover` state with border and background color changes
    - Added `:focus-visible` outline for keyboard navigation
    - Enhanced `.is-wounded` state with solid border and hover effects
  - Adjusted sizing and removed background/border from diagram container

- **Responsive & density adjustments**:
  - Removed `.wound-list`, `.wound-entry`, and `.wound-checkbox` density styles
  - Removed responsive grid-template-columns override for `.sla-wound-panel`
  - Updated diagram slot sizing in density breakpoints

## Implementation Details

The wound diagram is now a fully interactive, keyboard-accessible component. Each slot:
- Toggles the corresponding wound on click
- Displays visual feedback on hover and focus
- Uses semantic ARIA attributes for screen readers
- Maintains the same data binding to `system.wounds.*` properties

This eliminates redundant UI elements while improving usability and accessibility.

https://claude.ai/code/session_01B1BVVehb5XTPz3sPS5dzBN