### PR TITLE
fix: move inline Python out of release.yml to fix Prettier CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,7 @@ jobs:
               id: changelog
               run: |
                   VERSION="${{ steps.get-version.outputs.version }}"
-                  BODY=$(python3 -c "
-import re, sys
-text = open('CHANGELOG.md').read()
-version = sys.argv[1]
-m = re.search(r'\n## \[' + re.escape(version) + r'\][^\n]*\n(.*?)(?=\n## \[|\Z)', text, re.DOTALL)
-print(m.group(1).strip() if m else '')
-" "$VERSION")
+                  BODY=$(python3 scripts/extract-changelog.py "$VERSION")
                   echo "body<<EOF" >> "$GITHUB_OUTPUT"
                   echo "$BODY" >> "$GITHUB_OUTPUT"
                   echo "EOF" >> "$GITHUB_OUTPUT"

--- a/scripts/extract-changelog.py
+++ b/scripts/extract-changelog.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Extract the changelog entry for a given version from CHANGELOG.md."""
+
+import re
+import sys
+
+version = sys.argv[1]
+text = open("CHANGELOG.md").read()
+m = re.search(
+    r"\n## \[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=\n## \[|\Z)",
+    text,
+    re.DOTALL,
+)
+print(m.group(1).strip() if m else "")


### PR DESCRIPTION
Prettier's YAML parser rejects column-0 lines inside a block scalar, causing CI to fail with `SyntaxError: All collection items must start at the same column`.

Extracts the changelog snippet logic into `scripts/extract-changelog.py` and calls it from the workflow instead of embedding multi-line Python inline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1BVVehb5XTPz3sPS5dzBN)_