### PR TITLE
fix: dice breakdown toggle broken — hidden attribute vs inline style mismatch

### DIFF
--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -115,7 +115,7 @@ export function generateDiceTooltip(roll, baseModifier, luckBonus = 0, successDi
     const sdRaw = roll.terms[0] && roll.terms[0].results[0] ? roll.terms[0].results[0].result : 0;
     const sdTotal = sdRaw + baseModifier + luckBonus + successDieMod;
 
-    let html = `<div class="dice-tooltip" style="display:none; margin-top:10px; padding-top:5px; border-top:1px solid #444; font-size:0.8em; color:#ccc;">`;
+    let html = `<div class="dice-tooltip" hidden style="margin-top:10px; padding-top:5px; border-top:1px solid #444; font-size:0.8em; color:#ccc;">`;
     html += `<div><strong>Success Die:</strong> Raw ${sdRaw} + Base ${baseModifier}`;
     if (luckBonus > 0) html += ` + Luck ${luckBonus}`;
     if (successDieMod !== 0) html += ` + Mod ${successDieMod}`;

--- a/src/scss/sheets/actor/_density.scss
+++ b/src/scss/sheets/actor/_density.scss
@@ -134,14 +134,7 @@
 
 /* --- Wounds & conditions ------------------------------------------------- */
 .sla-sheet .sla-wound-diagram {
-    padding: 4px;
-    gap: 3px;
-}
-
-.sla-sheet .sla-wound-diagram__slot {
-    width: 36px;
-    height: 28px;
-    font-size: 0.58rem;
+    height: 86px;
 }
 
 .sla-sheet .condition-grid {

--- a/src/scss/sheets/actor/_density.scss
+++ b/src/scss/sheets/actor/_density.scss
@@ -146,7 +146,7 @@
 
 .sla-sheet .condition-grid {
     gap: 10px;
-    padding-top: 6px;
+    padding-top: 0;
     justify-content: flex-start;
 }
 

--- a/src/scss/sheets/actor/_ux-enhancements.scss
+++ b/src/scss/sheets/actor/_ux-enhancements.scss
@@ -113,6 +113,19 @@
     border-color: #8b0000 !important;
 }
 
+/* Wounds + conditions row */
+.sla-sheet .sla-wounds-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.sla-sheet .sla-wounds-row .condition-grid {
+    flex: 1;
+    border-top: none;
+    padding-top: 0;
+}
+
 /* Wound diagram */
 .sla-sheet .sla-wound-diagram {
     display: grid;

--- a/src/scss/sheets/actor/_ux-enhancements.scss
+++ b/src/scss/sheets/actor/_ux-enhancements.scss
@@ -118,13 +118,13 @@
     display: flex;
     align-items: center;
     gap: 12px;
+    width: fit-content;
+    margin: 0 auto;
 }
 
 .sla-sheet .sla-wounds-row .condition-grid {
-    flex: 1;
     border-top: none;
     padding-top: 0;
-    justify-content: space-between;
 }
 
 /* Wound diagram — SVG silhouette */

--- a/src/scss/sheets/actor/_ux-enhancements.scss
+++ b/src/scss/sheets/actor/_ux-enhancements.scss
@@ -124,6 +124,7 @@
     flex: 1;
     border-top: none;
     padding-top: 0;
+    justify-content: space-between;
 }
 
 /* Wound diagram — SVG silhouette */

--- a/src/scss/sheets/actor/_ux-enhancements.scss
+++ b/src/scss/sheets/actor/_ux-enhancements.scss
@@ -126,84 +126,42 @@
     padding-top: 0;
 }
 
-/* Wound diagram */
+/* Wound diagram — SVG silhouette */
 .sla-sheet .sla-wound-diagram {
-    display: grid;
-    grid-template-areas:
-        '. head .'
-        'larm torso rarm'
-        'lleg . rleg';
-    gap: 4px;
-    justify-items: center;
-    align-items: center;
-    justify-content: center;
-    padding: 6px;
-    margin-bottom: 4px;
+    height: 100px;
+    width: auto;
+    flex-shrink: 0;
+    overflow: visible;
 }
 
 .sla-sheet .sla-wound-diagram__slot {
-    width: 44px;
-    height: 34px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.65rem;
-    text-transform: uppercase;
-    color: #888;
-    border: 1px dashed #444;
-    border-radius: 3px;
+    fill: rgba(255, 255, 255, 0.04);
+    stroke: #555;
+    stroke-width: 1.5;
     cursor: pointer;
-    user-select: none;
     transition:
-        border-color 0.15s,
-        background 0.15s,
-        color 0.15s;
+        fill 0.15s,
+        stroke 0.15s;
 
     &:hover {
-        border-color: #777;
-        color: #bbb;
-        background: rgba(255, 255, 255, 0.05);
+        fill: rgba(255, 255, 255, 0.1);
+        stroke: #999;
     }
 
     &:focus-visible {
         outline: 2px solid var(--sla-accent);
-        outline-offset: 2px;
+        outline-offset: 3px;
     }
 
     &.is-wounded {
-        border-color: #ff5555;
-        border-style: solid;
-        background: rgba(255, 85, 85, 0.15);
-        color: #ffaaaa;
+        fill: rgba(255, 85, 85, 0.28);
+        stroke: #ff5555;
+        stroke-width: 1.5;
 
         &:hover {
-            border-color: #ff8888;
-            background: rgba(255, 85, 85, 0.25);
+            fill: rgba(255, 85, 85, 0.45);
+            stroke: #ff8888;
         }
-    }
-
-    &[data-area='head'] {
-        grid-area: head;
-    }
-
-    &[data-area='torso'] {
-        grid-area: torso;
-    }
-
-    &[data-area='larm'] {
-        grid-area: larm;
-    }
-
-    &[data-area='rarm'] {
-        grid-area: rarm;
-    }
-
-    &[data-area='lleg'] {
-        grid-area: lleg;
-    }
-
-    &[data-area='rleg'] {
-        grid-area: rleg;
     }
 }
 

--- a/templates/actor/parts/wounds.hbs
+++ b/templates/actor/parts/wounds.hbs
@@ -6,36 +6,40 @@
         {{#if woundCount}}
         <div class="sla-wound-summary">{{woundCountLabel}}</div>
         {{/if}}
-
-        <div class="sla-wound-diagram">
-            <div class="sla-wound-diagram__slot {{#if system.wounds.head}}is-wounded{{/if}}" data-area="head" data-wound="head" role="button" tabindex="0" aria-pressed="{{system.wounds.head}}" aria-label="{{localize 'SLA.ActorSheet.WoundHead'}}" title="{{localize 'SLA.ActorSheet.WoundHead'}}">Hd</div>
-            <div class="sla-wound-diagram__slot {{#if system.wounds.lArm}}is-wounded{{/if}}" data-area="larm" data-wound="lArm" role="button" tabindex="0" aria-pressed="{{system.wounds.lArm}}" aria-label="{{localize 'SLA.ActorSheet.WoundLArm'}}" title="{{localize 'SLA.ActorSheet.WoundLArm'}}">LA</div>
-            <div class="sla-wound-diagram__slot {{#if system.wounds.torso}}is-wounded{{/if}}" data-area="torso" data-wound="torso" role="button" tabindex="0" aria-pressed="{{system.wounds.torso}}" aria-label="{{localize 'SLA.ActorSheet.WoundTorso'}}" title="{{localize 'SLA.ActorSheet.WoundTorso'}}">To</div>
-            <div class="sla-wound-diagram__slot {{#if system.wounds.rArm}}is-wounded{{/if}}" data-area="rarm" data-wound="rArm" role="button" tabindex="0" aria-pressed="{{system.wounds.rArm}}" aria-label="{{localize 'SLA.ActorSheet.WoundRArm'}}" title="{{localize 'SLA.ActorSheet.WoundRArm'}}">RA</div>
-            <div class="sla-wound-diagram__slot {{#if system.wounds.lLeg}}is-wounded{{/if}}" data-area="lleg" data-wound="lLeg" role="button" tabindex="0" aria-pressed="{{system.wounds.lLeg}}" aria-label="{{localize 'SLA.ActorSheet.WoundLLeg'}}" title="{{localize 'SLA.ActorSheet.WoundLLeg'}}">LL</div>
-            <div class="sla-wound-diagram__slot {{#if system.wounds.rLeg}}is-wounded{{/if}}" data-area="rleg" data-wound="rLeg" role="button" tabindex="0" aria-pressed="{{system.wounds.rLeg}}" aria-label="{{localize 'SLA.ActorSheet.WoundRLeg'}}" title="{{localize 'SLA.ActorSheet.WoundRLeg'}}">RL</div>
-        </div>
         {{/if}}
 
-        <div class="condition-grid">
-            <a class="condition-toggle {{#if system.conditions.prone}}active{{/if}}" data-condition="prone" role="button" aria-pressed="{{system.conditions.prone}}" title="{{localize 'SLA.ActorSheet.ConditionProne'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionProne'}}">
-                <i class="fas fa-user-injured" aria-hidden="true"></i>
-            </a>
-            <a class="condition-toggle {{#if system.conditions.stunned}}active{{/if}}" data-condition="stunned" role="button" aria-pressed="{{system.conditions.stunned}}" title="{{localize 'SLA.ActorSheet.ConditionStunned'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionStunned'}}">
-                <i class="fas fa-dizzy" aria-hidden="true"></i>
-            </a>
-            <a class="condition-toggle {{#if system.conditions.burning}}active{{/if}}" data-condition="burning" role="button" aria-pressed="{{system.conditions.burning}}" title="{{localize 'SLA.ActorSheet.ConditionBurning'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionBurning'}}">
-                <i class="fas fa-fire" aria-hidden="true"></i>
-            </a>
-            <a class="condition-toggle {{#if system.conditions.bleeding}}active{{/if}}" data-condition="bleeding" role="button" aria-pressed="{{system.conditions.bleeding}}" title="{{localize 'SLA.ActorSheet.ConditionBleeding'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionBleeding'}}">
-                <i class="fas fa-tint" aria-hidden="true"></i>
-            </a>
-            <a class="condition-toggle {{#if system.conditions.immobile}}active{{/if}}" data-condition="immobile" role="button" aria-pressed="{{system.conditions.immobile}}" title="{{localize 'SLA.ActorSheet.ConditionImmobile'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionImmobile'}}">
-                <i class="fas fa-lock" aria-hidden="true"></i>
-            </a>
-            <span class="condition-toggle condition-automatic{{#if system.conditions.critical}} active{{/if}}" title="{{localize 'SLA.ActorSheet.ConditionCritical'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionCritical'}}">
-                <i class="fas fa-skull" aria-hidden="true"></i>
-            </span>
+        <div class="sla-wounds-row">
+            {{#if (ne enableNPCWoundTracking false)}}
+            <div class="sla-wound-diagram">
+                <div class="sla-wound-diagram__slot {{#if system.wounds.head}}is-wounded{{/if}}" data-area="head" data-wound="head" role="button" tabindex="0" aria-pressed="{{system.wounds.head}}" aria-label="{{localize 'SLA.ActorSheet.WoundHead'}}" title="{{localize 'SLA.ActorSheet.WoundHead'}}">Hd</div>
+                <div class="sla-wound-diagram__slot {{#if system.wounds.lArm}}is-wounded{{/if}}" data-area="larm" data-wound="lArm" role="button" tabindex="0" aria-pressed="{{system.wounds.lArm}}" aria-label="{{localize 'SLA.ActorSheet.WoundLArm'}}" title="{{localize 'SLA.ActorSheet.WoundLArm'}}">LA</div>
+                <div class="sla-wound-diagram__slot {{#if system.wounds.torso}}is-wounded{{/if}}" data-area="torso" data-wound="torso" role="button" tabindex="0" aria-pressed="{{system.wounds.torso}}" aria-label="{{localize 'SLA.ActorSheet.WoundTorso'}}" title="{{localize 'SLA.ActorSheet.WoundTorso'}}">To</div>
+                <div class="sla-wound-diagram__slot {{#if system.wounds.rArm}}is-wounded{{/if}}" data-area="rarm" data-wound="rArm" role="button" tabindex="0" aria-pressed="{{system.wounds.rArm}}" aria-label="{{localize 'SLA.ActorSheet.WoundRArm'}}" title="{{localize 'SLA.ActorSheet.WoundRArm'}}">RA</div>
+                <div class="sla-wound-diagram__slot {{#if system.wounds.lLeg}}is-wounded{{/if}}" data-area="lleg" data-wound="lLeg" role="button" tabindex="0" aria-pressed="{{system.wounds.lLeg}}" aria-label="{{localize 'SLA.ActorSheet.WoundLLeg'}}" title="{{localize 'SLA.ActorSheet.WoundLLeg'}}">LL</div>
+                <div class="sla-wound-diagram__slot {{#if system.wounds.rLeg}}is-wounded{{/if}}" data-area="rleg" data-wound="rLeg" role="button" tabindex="0" aria-pressed="{{system.wounds.rLeg}}" aria-label="{{localize 'SLA.ActorSheet.WoundRLeg'}}" title="{{localize 'SLA.ActorSheet.WoundRLeg'}}">RL</div>
+            </div>
+            {{/if}}
+
+            <div class="condition-grid">
+                <a class="condition-toggle {{#if system.conditions.prone}}active{{/if}}" data-condition="prone" role="button" aria-pressed="{{system.conditions.prone}}" title="{{localize 'SLA.ActorSheet.ConditionProne'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionProne'}}">
+                    <i class="fas fa-user-injured" aria-hidden="true"></i>
+                </a>
+                <a class="condition-toggle {{#if system.conditions.stunned}}active{{/if}}" data-condition="stunned" role="button" aria-pressed="{{system.conditions.stunned}}" title="{{localize 'SLA.ActorSheet.ConditionStunned'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionStunned'}}">
+                    <i class="fas fa-dizzy" aria-hidden="true"></i>
+                </a>
+                <a class="condition-toggle {{#if system.conditions.burning}}active{{/if}}" data-condition="burning" role="button" aria-pressed="{{system.conditions.burning}}" title="{{localize 'SLA.ActorSheet.ConditionBurning'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionBurning'}}">
+                    <i class="fas fa-fire" aria-hidden="true"></i>
+                </a>
+                <a class="condition-toggle {{#if system.conditions.bleeding}}active{{/if}}" data-condition="bleeding" role="button" aria-pressed="{{system.conditions.bleeding}}" title="{{localize 'SLA.ActorSheet.ConditionBleeding'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionBleeding'}}">
+                    <i class="fas fa-tint" aria-hidden="true"></i>
+                </a>
+                <a class="condition-toggle {{#if system.conditions.immobile}}active{{/if}}" data-condition="immobile" role="button" aria-pressed="{{system.conditions.immobile}}" title="{{localize 'SLA.ActorSheet.ConditionImmobile'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionImmobile'}}">
+                    <i class="fas fa-lock" aria-hidden="true"></i>
+                </a>
+                <span class="condition-toggle condition-automatic{{#if system.conditions.critical}} active{{/if}}" title="{{localize 'SLA.ActorSheet.ConditionCritical'}}" aria-label="{{localize 'SLA.ActorSheet.ConditionCritical'}}">
+                    <i class="fas fa-skull" aria-hidden="true"></i>
+                </span>
+            </div>
         </div>
     </div>
 </div>

--- a/templates/actor/parts/wounds.hbs
+++ b/templates/actor/parts/wounds.hbs
@@ -10,14 +10,14 @@
 
         <div class="sla-wounds-row">
             {{#if (ne enableNPCWoundTracking false)}}
-            <div class="sla-wound-diagram">
-                <div class="sla-wound-diagram__slot {{#if system.wounds.head}}is-wounded{{/if}}" data-area="head" data-wound="head" role="button" tabindex="0" aria-pressed="{{system.wounds.head}}" aria-label="{{localize 'SLA.ActorSheet.WoundHead'}}" title="{{localize 'SLA.ActorSheet.WoundHead'}}">Hd</div>
-                <div class="sla-wound-diagram__slot {{#if system.wounds.lArm}}is-wounded{{/if}}" data-area="larm" data-wound="lArm" role="button" tabindex="0" aria-pressed="{{system.wounds.lArm}}" aria-label="{{localize 'SLA.ActorSheet.WoundLArm'}}" title="{{localize 'SLA.ActorSheet.WoundLArm'}}">LA</div>
-                <div class="sla-wound-diagram__slot {{#if system.wounds.torso}}is-wounded{{/if}}" data-area="torso" data-wound="torso" role="button" tabindex="0" aria-pressed="{{system.wounds.torso}}" aria-label="{{localize 'SLA.ActorSheet.WoundTorso'}}" title="{{localize 'SLA.ActorSheet.WoundTorso'}}">To</div>
-                <div class="sla-wound-diagram__slot {{#if system.wounds.rArm}}is-wounded{{/if}}" data-area="rarm" data-wound="rArm" role="button" tabindex="0" aria-pressed="{{system.wounds.rArm}}" aria-label="{{localize 'SLA.ActorSheet.WoundRArm'}}" title="{{localize 'SLA.ActorSheet.WoundRArm'}}">RA</div>
-                <div class="sla-wound-diagram__slot {{#if system.wounds.lLeg}}is-wounded{{/if}}" data-area="lleg" data-wound="lLeg" role="button" tabindex="0" aria-pressed="{{system.wounds.lLeg}}" aria-label="{{localize 'SLA.ActorSheet.WoundLLeg'}}" title="{{localize 'SLA.ActorSheet.WoundLLeg'}}">LL</div>
-                <div class="sla-wound-diagram__slot {{#if system.wounds.rLeg}}is-wounded{{/if}}" data-area="rleg" data-wound="rLeg" role="button" tabindex="0" aria-pressed="{{system.wounds.rLeg}}" aria-label="{{localize 'SLA.ActorSheet.WoundRLeg'}}" title="{{localize 'SLA.ActorSheet.WoundRLeg'}}">RL</div>
-            </div>
+            <svg class="sla-wound-diagram" viewBox="0 0 70 115" xmlns="http://www.w3.org/2000/svg" aria-label="{{localize 'SLA.ActorSheet.WoundsStatus'}}">
+                <circle class="sla-wound-diagram__slot {{#if system.wounds.head}}is-wounded{{/if}}" data-wound="head" cx="35" cy="11" r="10" role="button" tabindex="0" aria-pressed="{{system.wounds.head}}" aria-label="{{localize 'SLA.ActorSheet.WoundHead'}}" title="{{localize 'SLA.ActorSheet.WoundHead'}}"/>
+                <rect class="sla-wound-diagram__slot {{#if system.wounds.lArm}}is-wounded{{/if}}" data-wound="lArm" x="4" y="24" width="12" height="34" rx="3" role="button" tabindex="0" aria-pressed="{{system.wounds.lArm}}" aria-label="{{localize 'SLA.ActorSheet.WoundLArm'}}" title="{{localize 'SLA.ActorSheet.WoundLArm'}}"/>
+                <rect class="sla-wound-diagram__slot {{#if system.wounds.torso}}is-wounded{{/if}}" data-wound="torso" x="19" y="24" width="32" height="38" rx="3" role="button" tabindex="0" aria-pressed="{{system.wounds.torso}}" aria-label="{{localize 'SLA.ActorSheet.WoundTorso'}}" title="{{localize 'SLA.ActorSheet.WoundTorso'}}"/>
+                <rect class="sla-wound-diagram__slot {{#if system.wounds.rArm}}is-wounded{{/if}}" data-wound="rArm" x="54" y="24" width="12" height="34" rx="3" role="button" tabindex="0" aria-pressed="{{system.wounds.rArm}}" aria-label="{{localize 'SLA.ActorSheet.WoundRArm'}}" title="{{localize 'SLA.ActorSheet.WoundRArm'}}"/>
+                <rect class="sla-wound-diagram__slot {{#if system.wounds.lLeg}}is-wounded{{/if}}" data-wound="lLeg" x="19" y="65" width="14" height="50" rx="3" role="button" tabindex="0" aria-pressed="{{system.wounds.lLeg}}" aria-label="{{localize 'SLA.ActorSheet.WoundLLeg'}}" title="{{localize 'SLA.ActorSheet.WoundLLeg'}}"/>
+                <rect class="sla-wound-diagram__slot {{#if system.wounds.rLeg}}is-wounded{{/if}}" data-wound="rLeg" x="37" y="65" width="14" height="50" rx="3" role="button" tabindex="0" aria-pressed="{{system.wounds.rLeg}}" aria-label="{{localize 'SLA.ActorSheet.WoundRLeg'}}" title="{{localize 'SLA.ActorSheet.WoundRLeg'}}"/>
+            </svg>
             {{/if}}
 
             <div class="condition-grid">


### PR DESCRIPTION
Clicking the success die number in a roll card never revealed the dice breakdown.

**Root cause:** `toggleTooltip()` checks for the `hidden` HTML attribute, but the tooltip was rendered with `style="display:none"`. First click added `hidden` (tooltip already invisible); second click removed `hidden` but the inline style kept it hidden. The toggle never actually showed anything.

**Fix:** Generate the tooltip with `hidden` attribute instead of `style="display:none"` so the toggle works correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1BVVehb5XTPz3sPS5dzBN)_