### PR TITLE
fix: dice breakdown toggle broken — hidden attribute vs inline style mismatch

### DIFF
--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -115,7 +115,7 @@ export function generateDiceTooltip(roll, baseModifier, luckBonus = 0, successDi
     const sdRaw = roll.terms[0] && roll.terms[0].results[0] ? roll.terms[0].results[0].result : 0;
     const sdTotal = sdRaw + baseModifier + luckBonus + successDieMod;
 
-    let html = `<div class="dice-tooltip" style="display:none; margin-top:10px; padding-top:5px; border-top:1px solid #444; font-size:0.8em; color:#ccc;">`;
+    let html = `<div class="dice-tooltip" hidden style="margin-top:10px; padding-top:5px; border-top:1px solid #444; font-size:0.8em; color:#ccc;">`;
     html += `<div><strong>Success Die:</strong> Raw ${sdRaw} + Base ${baseModifier}`;
     if (luckBonus > 0) html += ` + Luck ${luckBonus}`;
     if (successDieMod !== 0) html += ` + Mod ${successDieMod}`;


### PR DESCRIPTION
Clicking the success die number in a roll card never revealed the dice breakdown.

**Root cause:** `toggleTooltip()` checks for the `hidden` HTML attribute, but the tooltip was rendered with `style="display:none"`. First click added `hidden` (already invisible); second click removed `hidden` but the inline style kept it hidden — so it never actually showed anything.

**Fix:** Generate the tooltip with the `hidden` attribute instead of `style="display:none"` so the toggle works correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1BVVehb5XTPz3sPS5dzBN)_