### PR TITLE
chore: bump version to 2.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.8.3] - 2026-06-11
+
+### Fixed
+
+- **Dice breakdown toggle:** Clicking the success die result number on a roll card now correctly shows/hides the dice breakdown. The tooltip was generated with `style="display:none"` but the toggle handler checked for the `hidden` attribute, so the breakdown was never visible.
+- **Wound tracking UI:** Interactive SVG paperdoll replaces checkbox/label wound list; wound diagram and condition toggles share a single centred row.
+
 ## [2.8.2] - 2026-06-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sla-industries",
-    "version": "2.8.2",
+    "version": "2.8.3",
     "description": "CSS compiler for the SLA Industries system",
     "scripts": {
         "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "sla-industries",
     "title": "SLA Industries 2nd Edition",
     "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-    "version": "2.8.2",
+    "version": "2.8.3",
     "compatibility": {
         "minimum": "14",
         "verified": "14.360"
@@ -46,7 +46,7 @@
     ],
     "url": "https://github.com/VacantFanatic/sla-foundry",
     "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.2/sla-industries.zip",
+    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.3/sla-industries.zip",
     "packs": [
         {
             "name": "skills",


### PR DESCRIPTION
Bumps version to 2.8.3 for release.

**Includes:**
- Fix: dice breakdown toggle broken (hidden attribute vs `style="display:none"` mismatch)
- Wound tracking UI rework: SVG paperdoll silhouette, centred wound+condition row

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1BVVehb5XTPz3sPS5dzBN)_