### PR TITLE
chore: bump version to 2.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.8.4] - 2026-06-11
+
+### Changed
+
+- **Vitals moved to Combat tab:** HP bar, Hit Points, and Armor PV now appear inside the Status & Wounds panel on the Combat tab. A horizontal flex row puts vitals on the left and the wound diagram + conditions on the right, grouping all combat-health state in one place.
+
 ## [2.8.3] - 2026-06-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sla-industries",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "description": "CSS compiler for the SLA Industries system",
     "scripts": {
         "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "sla-industries",
     "title": "SLA Industries 2nd Edition",
     "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "compatibility": {
         "minimum": "14",
         "verified": "14.360"
@@ -46,7 +46,7 @@
     ],
     "url": "https://github.com/VacantFanatic/sla-foundry",
     "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.3/sla-industries.zip",
+    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.4/sla-industries.zip",
     "packs": [
         {
             "name": "skills",


### PR DESCRIPTION
Bumps to 2.8.4 — includes the Vitals-in-combat-tab layout change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B1BVVehb5XTPz3sPS5dzBN)_