### PR TITLE
Fix Threat sheet HP/Armor inputs corrupting form data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.8.5] - 2026-06-16
+
 ### Fixed
 
 - **Threat (NPC) sheet edits not saving:** The 2.8.4 "vitals moved to Combat tab" change added HP/Armor inputs to the shared wounds panel, but the Threat sheet header still rendered its own copy of those same fields. Duplicate `name` attributes in the same form corrupted the submitted data and silently dropped the whole update, so core stats, armor, HP, and movement edits appeared not to save. The header's redundant HP/Armor inputs are removed; the Combat tab's wounds panel is now the single source for those fields.
@@ -935,7 +937,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Damage application targeting both selected token and target.
 - Degree of success display regression on weapon attacks.
 
-[Unreleased]: https://github.com/VacantFanatic/sla-foundry/compare/2.8.2...HEAD
+[Unreleased]: https://github.com/VacantFanatic/sla-foundry/compare/2.8.5...HEAD
+[2.8.5]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.8.5
 [2.8.2]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.8.2
 [2.5.4]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.4
 [2.5.3]: https://github.com/VacantFanatic/sla-foundry/releases/tag/2.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Threat (NPC) sheet edits not saving:** The 2.8.4 "vitals moved to Combat tab" change added HP/Armor inputs to the shared wounds panel, but the Threat sheet header still rendered its own copy of those same fields. Duplicate `name` attributes in the same form corrupted the submitted data and silently dropped the whole update, so core stats, armor, HP, and movement edits appeared not to save. The header's redundant HP/Armor inputs are removed; the Combat tab's wounds panel is now the single source for those fields.
+
 ## [2.8.4] - 2026-06-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sla-industries",
-    "version": "2.8.2",
+    "version": "2.8.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sla-industries",
-            "version": "2.8.2",
+            "version": "2.8.5",
             "license": "MIT",
             "devDependencies": {
                 "@playwright/test": "^1.49.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sla-industries",
-    "version": "2.8.4",
+    "version": "2.8.5",
     "description": "CSS compiler for the SLA Industries system",
     "scripts": {
         "build:css": "sass src/scss/sla-industries.scss css/sla-industries.css --style=expanded --no-source-map",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "id": "sla-industries",
     "title": "SLA Industries 2nd Edition",
     "description": "A fully automated character sheet and combat system for SLA Industries 2nd Edition (S5S). Features include calculated derived stats, S5S dice rolling, species limits, and custom weapon/armor logic.",
-    "version": "2.8.4",
+    "version": "2.8.5",
     "compatibility": {
         "minimum": "14",
         "verified": "14.360"
@@ -46,7 +46,7 @@
     ],
     "url": "https://github.com/VacantFanatic/sla-foundry",
     "manifest": "https://github.com/VacantFanatic/sla-foundry/releases/latest/download/system.json",
-    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.4/sla-industries.zip",
+    "download": "https://github.com/VacantFanatic/sla-foundry/releases/download/2.8.5/sla-industries.zip",
     "packs": [
         {
             "name": "skills",

--- a/templates/actor/actor-npc-sheet-v2.hbs
+++ b/templates/actor/actor-npc-sheet-v2.hbs
@@ -45,18 +45,6 @@
         {{!-- DERIVED STATS --}}
         <div class="threat-derived">
             <div class="threat-box">
-                <label>HP</label>
-                <div class="flexrow">
-                    <input type="number" name="system.hp.value" value="{{system.hp.value}}" />
-                    <span>/</span>
-                    <input type="number" name="system.hp.max" value="{{system.hp.max}}" />
-                </div>
-            </div>
-            <div class="threat-box">
-                <label>ARMOR</label>
-                <input type="number" name="system.armor.pv" value="{{system.armor.value}}" placeholder="0" />
-            </div>
-            <div class="threat-box">
                 <label>INIT</label>
                 <div class="flexrow">
                     {{!-- FIX: Changed from Span to Input --}}


### PR DESCRIPTION
## Summary

Fixes a critical bug where edits to core stats, armor, HP, and movement on the Threat (NPC) sheet appeared not to save. The root cause was duplicate form field names (`system.hp.value`, `system.hp.max`, `system.armor.pv`) in the same form, which corrupted the submitted data and silently dropped the entire update.

## Changes

- **Removed redundant HP/Armor inputs from Threat sheet header** (`templates/actor/actor-npc-sheet-v2.hbs`)
  - The 2.8.4 release moved HP and Armor fields to the Combat tab's wounds panel
  - The header was still rendering its own copy of these fields, creating duplicate `name` attributes
  - Duplicate field names in a single form cause the browser to submit conflicting data, breaking the entire update
  - The Combat tab's wounds panel is now the single source of truth for HP and Armor

- **Updated version to 2.8.5** in `system.json` and `package.json`
- **Added changelog entry** documenting the fix

## Impact

Users can now successfully save edits to Threat sheet stats, armor, HP, and movement. The form no longer silently fails due to duplicate field names.