### PR TITLE
docs: add CONTRIBUTING and SECURITY guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing to SLA Industries – Foundry VTT System
+
+Thanks for your interest in contributing. This is an unofficial fan project; all contributions are welcome whether you're fixing a bug, adding a mechanic, improving styles, or updating docs.
+
+## Quick start
+
+```bash
+git clone https://github.com/VacantFanatic/sla-foundry.git
+cd sla-foundry
+npm ci
+npm run build        # compile SCSS → css/
+npm run test:unit    # run unit tests (no Foundry required)
+```
+
+See [CLAUDE.md](CLAUDE.md) and [`.docs/DEVELOPER.md`](.docs/DEVELOPER.md) for full environment setup, including optional Foundry VTT installation for E2E testing.
+
+## Development workflow
+
+### Branching
+
+- Branch from `main` with a short descriptive name: `fix/reload-ammo-check`, `feat/ebb-flux-ui`.
+- Keep branches focused — one concern per PR.
+
+### Test-driven development
+
+Follow TDD for all logic changes:
+
+1. Write a failing unit test in `tests/unit/` that captures the expected behaviour.
+2. Implement the minimum code to make it pass.
+3. Refactor, keeping tests green.
+
+```bash
+npm run test:unit
+```
+
+Tests use Node's built-in test runner — no Foundry license required.
+
+### Code style
+
+All code must pass [Prettier](https://prettier.io/) before being committed:
+
+```bash
+npm run format          # auto-fix
+npm run format:check    # check only (what CI runs)
+```
+
+CI blocks any PR that fails the format check.
+
+### SCSS
+
+After editing `.scss` files under `src/scss/`, compile before testing in Foundry:
+
+```bash
+npm run build:css
+```
+
+## Opening a pull request
+
+1. Ensure `npm run format:check` and `npm run test:unit` both pass locally.
+2. Update [CHANGELOG.md](CHANGELOG.md) under the current draft `## [Unreleased]` section.
+3. Open a PR against `main` with a clear title and description explaining **what** changed and **why**.
+4. Link any related issues (`Closes #123`).
+
+CI will run Prettier, unit tests, and dist validation automatically. A maintainer will review and merge once checks are green.
+
+## Reporting bugs
+
+Open a [GitHub issue](https://github.com/VacantFanatic/sla-foundry/issues) with:
+
+- Foundry VTT version and system version (Settings → System)
+- Steps to reproduce
+- What you expected vs. what happened
+- Browser console errors if applicable
+
+## Security issues
+
+Do **not** open public issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the private reporting process.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's [MIT License](package.json).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest stable release receives security fixes.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | Yes       |
+| Older   | No        |
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report security concerns privately via [GitHub's private vulnerability reporting](https://github.com/VacantFanatic/sla-foundry/security/advisories/new).
+
+Include as much of the following as possible:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Affected version(s)
+- Any suggested fix or mitigation
+
+You should receive an acknowledgement within **7 days**. If you do not hear back, follow up by email at the address listed on the maintainer's GitHub profile.
+
+## Scope
+
+This is an unofficial fan-made **Foundry VTT game system** (client-side JavaScript, Handlebars templates, and SCSS). It runs entirely within a Foundry VTT server that the GM hosts. Relevant security concerns include:
+
+- Cross-site scripting (XSS) via user-supplied HTML in actor/item fields
+- Privilege escalation within Foundry's permission model
+- Data leakage between players via the system's socket or API calls
+
+Out of scope: vulnerabilities in Foundry VTT core, Node.js, or the host OS. Report those to [Foundry VTT](https://foundryvtt.com/article/reporting-issues/) or the relevant upstream project.
+
+## Disclosure
+
+Once a fix is released, the vulnerability will be documented in [CHANGELOG.md](CHANGELOG.md) and credited to the reporter (unless anonymity is requested).


### PR DESCRIPTION
## Summary

Add comprehensive contributor and security documentation to establish clear guidelines for community contributions and vulnerability reporting.

## Changes

- **CONTRIBUTING.md** — New contributor guide covering:
  - Quick start setup (git clone, npm ci, build, test commands)
  - Development workflow (branching strategy, TDD requirements, code style with Prettier, SCSS compilation)
  - PR submission checklist (format check, unit tests, CHANGELOG updates, CI expectations)
  - Bug reporting template
  - Security issue reporting redirect

- **SECURITY.md** — New security policy covering:
  - Supported versions (latest only)
  - Private vulnerability reporting via GitHub Security Advisories
  - Scope definition (XSS, privilege escalation, data leakage in-scope; Foundry/Node/OS out-of-scope)
  - Disclosure and credit process

## Implementation details

Both documents align with existing project conventions from CLAUDE.md and AGENTS.md:
- Emphasize TDD and Prettier formatting as CI requirements
- Reference existing developer docs (.docs/DEVELOPER.md, CLAUDE.md)
- Direct security reports away from public issues to private channels
- Clarify that this is an unofficial fan project with MIT licensing

https://claude.ai/code/session_018Vs7J8mn2RAXPduTeweJAA